### PR TITLE
重构：消息块样式获得拖动动效与悬浮高光

### DIFF
--- a/ui/src/views/chat/chat.vue
+++ b/ui/src/views/chat/chat.vue
@@ -8493,6 +8493,26 @@ onBeforeUnmount(() => {
   transition: transform 0.2s ease;
 }
 
+/* Subtle hover highlight for message positioning - compact mode only */
+.message-row .message-row__surface {
+  position: relative;
+}
+
+.chat--layout-compact .message-row:not(.message-row--search-hit):hover .message-row__surface::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(128, 128, 128, 0.07);
+  pointer-events: none;
+  z-index: 0;
+  transition: opacity 0.15s ease;
+}
+
+:global(.dark) .chat--layout-compact .message-row:not(.message-row--search-hit):hover .message-row__surface::after {
+  background: rgba(128, 128, 128, 0.1);
+}
+
 /* Dragged message highlight during live reorder */
 .message-row--drag-source {
   position: relative;


### PR DESCRIPTION
[重构：拖动消息时添加清晰的动效](https://github.com/kagangtuya-star/sealchat/commit/251ad6fdcb2d1ad2fe84e22831a0f4946eb2d538)

[功能：紧凑模式下，鼠标悬浮到消息上会有轻微的高光强调](https://github.com/kagangtuya-star/sealchat/commit/7fcdd840b02098aea7b0a46779125be7b6d11c14)