### PR TITLE
v2026-04-11-Broadcast

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,53 +1,57 @@
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
+# Normalize text files to LF by default so Windows Git and WSL Git
+# see the same repository content.
+* text=auto eol=lf
 
-# Test binary, built with `go test -c`
-*.test
+# Windows-native scripts keep CRLF for better shell compatibility.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
 
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
+# Common text sources kept explicit for readability.
+*.go text eol=lf
+*.mod text eol=lf
+*.sum text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.xml text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.js text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.vue text eol=lf
+*.sh text eol=lf
+*.sql text eol=lf
+Dockerfile text eol=lf
+*.dockerignore text eol=lf
+*.gitignore text eol=lf
+*.gitattributes text eol=lf
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
-info.db
-record.log
-go.sum
-.idea
-sealdice-core
-data/save.yaml
-configs/
-data/
-pegtest/
-temp/
-
-dist/
-config.yaml
-version.yaml
-assets/
-data.db
-chat.db
-static/
-/已经实现的需求
-/.cache
-/.gocache
-/.gomodcache
-/docs
-/plans
-/specs
-/.codanna
-/.serena
-.codannaignore
-.fastembed_cache
-/.gopath
-!bin/win-x64/*.exe
-/sealchat-data
-.ace-tool/
-/.claude
-api/CLAUDE.md
-CLAUDE.md
-backup_settings.patch
+# Binary assets must never be line-ending normalized.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.tgz binary
+*.7z binary
+*.db binary
+*.sqlite binary
+*.sqlite3 binary
+*.exe binary
+*.dll binary
+*.so binary
+*.dylib binary
+*.woff binary
+*.woff2 binary

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ CLAUDE.md
 backup_settings.patch
 /openspec
 /build
+/.superpowers

--- a/api/announcement.go
+++ b/api/announcement.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,11 +39,18 @@ func mapAnnouncementErrorStatus(err error) int {
 }
 
 func parseAnnouncementListOptions(c *fiber.Ctx) service.AnnouncementListOptions {
+	var showInTicker *bool
+	if raw := strings.TrimSpace(c.Query("showInTicker")); raw != "" {
+		if parsed, err := strconv.ParseBool(raw); err == nil {
+			showInTicker = &parsed
+		}
+	}
 	return service.AnnouncementListOptions{
 		Page:            parseQueryIntDefault(c, "page", 1),
 		PageSize:        parseQueryIntDefault(c, "pageSize", 20),
 		IncludeAll:      c.QueryBool("includeAll"),
 		IncludeArchived: c.QueryBool("includeArchived"),
+		ShowInTicker:    showInTicker,
 	}
 }
 

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -370,6 +370,8 @@ func Init(config *utils.AppConfig, uiStatic fs.FS) {
 	v1Auth.Put("/character-card-templates/:id", CharacterCardTemplateUpdate)
 	v1Auth.Delete("/character-card-templates/:id", CharacterCardTemplateDelete)
 	v1Auth.Post("/character-card-templates/:id/set-default", CharacterCardTemplateSetDefault)
+	v1Auth.Post("/worlds/:worldId/character-card-templates/:templateId/share", WorldCharacterCardTemplateShareHandler)
+	v1Auth.Delete("/worlds/:worldId/character-card-templates/:templateId/share", WorldCharacterCardTemplateUnshareHandler)
 	v1Auth.Get("/character-card-template-bindings", CharacterCardTemplateBindingList)
 	v1Auth.Post("/character-card-template-bindings/upsert", CharacterCardTemplateBindingUpsert)
 	v1Auth.Get("/character-card-avatar-bindings", CharacterCardAvatarBindingList)

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -619,6 +619,12 @@ func Init(config *utils.AppConfig, uiStatic fs.FS) {
 	v1AuthAdmin.Post("/admin/external-glossaries/:libraryId/categories/delete", ExternalGlossaryCategoryDeleteHandler)
 	v1AuthAdmin.Post("/admin/external-glossaries/:libraryId/categories/priority", ExternalGlossaryCategoryPriorityUpdateHandler)
 	v1AuthAdmin.Post("/admin/external-glossaries/:libraryId/categories/priority/bulk", ExternalGlossaryCategoryPriorityBulkUpdateHandler)
+	v1AuthAdmin.Get("/admin/audio-assets", AdminAudioAssetList)
+	v1AuthAdmin.Get("/admin/audio-assets/:id/usage", AdminAudioAssetUsageGet)
+	v1AuthAdmin.Delete("/admin/audio-assets/:id", AdminAudioAssetDeleteSafe)
+	v1AuthAdmin.Post("/admin/audio-assets/bulk-delete", AdminAudioAssetBulkDeleteSafe)
+	v1AuthAdmin.Get("/admin/audio-assets/cleanup-preview", AdminAudioAssetCleanupPreview)
+	v1AuthAdmin.Post("/admin/audio-assets/cleanup", AdminAudioAssetCleanupExecute)
 
 	// Image migration routes
 	v1AuthAdmin.Get("/admin/image-migration/preview", ImageMigrationPreview)

--- a/api/audio.go
+++ b/api/audio.go
@@ -941,17 +941,15 @@ func AdminAudioAssetDeleteSafe(c *fiber.Ctx) error {
 		return wrapErrorStatus(c, fiber.StatusBadRequest, nil, "缺少资源ID")
 	}
 	hard := c.QueryBool("hard")
-	if err := service.AudioSafeDeleteAsset(id, hard); err != nil {
-		var referencedErr *service.AudioAssetReferencedError
-		if errors.As(err, &referencedErr) {
-			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
-				"message": "素材仍被引用，无法安全删除",
-				"usage":   referencedErr.Summary,
-			})
+	impact, err := service.AdminAudioDeleteAsset(id, hard)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return wrapErrorStatus(c, fiber.StatusNotFound, err, "素材不存在")
 		}
 		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "删除素材失败")
 	}
-	return c.JSON(fiber.Map{"message": "已删除"})
+	broadcastAdminAudioDetachedScopes(getCurUser(c), impact)
+	return c.JSON(fiber.Map{"message": "已删除", "impact": impact})
 }
 
 func AdminAudioAssetBulkDeleteSafe(c *fiber.Ctx) error {
@@ -962,10 +960,11 @@ func AdminAudioAssetBulkDeleteSafe(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return wrapErrorStatus(c, fiber.StatusBadRequest, err, "请求体格式错误")
 	}
-	result, err := service.AudioSafeDeleteAssets(req.IDs, req.Hard)
+	result, err := service.AdminAudioDeleteAssets(req.IDs, req.Hard)
 	if err != nil {
 		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "批量安全删除失败")
 	}
+	broadcastAdminAudioDetachedScopes(getCurUser(c), &service.AudioDeleteImpact{PlaybackScopeLabels: result.PlaybackScopeLabels})
 	return c.JSON(result)
 }
 
@@ -1030,7 +1029,29 @@ func AdminAudioAssetCleanupExecute(c *fiber.Ctx) error {
 	if err != nil {
 		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "执行清理失败")
 	}
+	broadcastAdminAudioDetachedScopes(getCurUser(c), &service.AudioDeleteImpact{PlaybackScopeLabels: result.PlaybackScopeLabels})
 	return c.JSON(result)
+}
+
+func broadcastAdminAudioDetachedScopes(operator *model.UserModel, impact *service.AudioDeleteImpact) {
+	if operator == nil || impact == nil || len(impact.PlaybackScopeLabels) == 0 {
+		return
+	}
+	for _, scopeLabel := range impact.PlaybackScopeLabels {
+		label := strings.TrimSpace(scopeLabel)
+		if label == "" {
+			continue
+		}
+		state, err := service.AudioGetPlaybackState(label)
+		if err != nil {
+			log.Printf("[audio-admin] broadcast detached playback scope failed scope=%s err=%v", label, err)
+			continue
+		}
+		if state == nil {
+			continue
+		}
+		broadcastAudioPlaybackState(operator, state)
+	}
 }
 
 type audioSceneRequest struct {

--- a/api/audio.go
+++ b/api/audio.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -394,7 +395,14 @@ func AudioAssetDelete(c *fiber.Ctx) error {
 		}
 	}
 	hard := c.QueryBool("hard")
-	if err := service.AudioDeleteAsset(id, hard); err != nil {
+	if err := service.AudioSafeDeleteAsset(id, hard); err != nil {
+		var referencedErr *service.AudioAssetReferencedError
+		if errors.As(err, &referencedErr) {
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"message": "素材仍被引用，无法安全删除",
+				"usage":   referencedErr.Summary,
+			})
+		}
 		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "删除素材失败")
 	}
 	return c.JSON(fiber.Map{"message": "已删除"})
@@ -781,6 +789,9 @@ func AudioAssetStream(c *fiber.Ctx) error {
 		if target == "" || !strings.HasPrefix(strings.ToLower(target), "http") {
 			return wrapErrorStatus(c, fiber.StatusNotFound, nil, "音频文件不存在或已失效")
 		}
+		if err := service.AudioTouchAssetAccess(asset.ID); err != nil {
+			log.Printf("[audio] update access stats failed for %s: %v", asset.ID, err)
+		}
 		return c.Redirect(target, fiber.StatusTemporaryRedirect)
 	}
 	file, info, resolved, err := service.AudioOpenLocalVariant(asset, variantLabel)
@@ -790,6 +801,9 @@ func AudioAssetStream(c *fiber.Ctx) error {
 
 	if resolved.ObjectKey != "" {
 		variant = resolved
+	}
+	if err := service.AudioTouchAssetAccess(asset.ID); err != nil {
+		log.Printf("[audio] update access stats failed for %s: %v", asset.ID, err)
 	}
 	contentType := guessContentType(variant.ObjectKey)
 	c.Set("X-Asset-Bitrate", strconv.Itoa(variant.BitrateKbps))
@@ -862,6 +876,161 @@ func AudioPlaybackStateSet(c *fiber.Ctx) error {
 		broadcastAudioPlaybackState(user, state)
 	}
 	return c.JSON(fiber.Map{"state": buildAudioPlaybackResponse(state)})
+}
+
+func AdminAudioAssetList(c *fiber.Ctx) error {
+	filters := service.AdminAudioAssetFilters{
+		Query:      strings.TrimSpace(c.Query("query")),
+		QueryField: strings.TrimSpace(c.Query("queryField")),
+		SortBy:     strings.TrimSpace(c.Query("sortBy")),
+		SortOrder:  strings.TrimSpace(c.Query("sortOrder")),
+		Page:       c.QueryInt("page", 1),
+		PageSize:   c.QueryInt("pageSize", 20),
+	}
+	if scope := strings.TrimSpace(c.Query("scope")); scope != "" && scope != "all" {
+		filters.Scope = model.AudioAssetScope(scope)
+	}
+	if worldID := strings.TrimSpace(c.Query("worldId")); worldID != "" {
+		filters.WorldID = &worldID
+	}
+	if creatorID := strings.TrimSpace(c.Query("creatorId")); creatorID != "" {
+		filters.CreatorID = &creatorID
+	}
+	if referenced, ok := queryOptionalBool(c, "referenced"); ok {
+		filters.Referenced = &referenced
+	}
+	if neverAccessed, ok := queryOptionalBool(c, "neverAccessed"); ok {
+		filters.NeverAccessed = &neverAccessed
+	}
+	if inactiveDays := c.QueryInt("inactiveDays", 0); inactiveDays > 0 {
+		filters.InactiveDays = inactiveDays
+	}
+	result, err := service.AdminAudioListAssets(filters)
+	if err != nil {
+		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "读取平台音频素材失败")
+	}
+	return c.JSON(result)
+}
+
+func AdminAudioAssetUsageGet(c *fiber.Ctx) error {
+	id := strings.TrimSpace(c.Params("id"))
+	if id == "" {
+		return wrapErrorStatus(c, fiber.StatusBadRequest, nil, "缺少资源ID")
+	}
+	asset, err := service.AudioGetAsset(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return wrapErrorStatus(c, fiber.StatusNotFound, err, "素材不存在")
+		}
+		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "读取素材失败")
+	}
+	usage, err := service.AudioGetAssetUsageSummary(id)
+	if err != nil {
+		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "读取素材引用信息失败")
+	}
+	return c.JSON(fiber.Map{
+		"item":         asset,
+		"usageSummary": usage,
+		"safeToDelete": !usage.Referenced,
+	})
+}
+
+func AdminAudioAssetDeleteSafe(c *fiber.Ctx) error {
+	id := strings.TrimSpace(c.Params("id"))
+	if id == "" {
+		return wrapErrorStatus(c, fiber.StatusBadRequest, nil, "缺少资源ID")
+	}
+	hard := c.QueryBool("hard")
+	if err := service.AudioSafeDeleteAsset(id, hard); err != nil {
+		var referencedErr *service.AudioAssetReferencedError
+		if errors.As(err, &referencedErr) {
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"message": "素材仍被引用，无法安全删除",
+				"usage":   referencedErr.Summary,
+			})
+		}
+		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "删除素材失败")
+	}
+	return c.JSON(fiber.Map{"message": "已删除"})
+}
+
+func AdminAudioAssetBulkDeleteSafe(c *fiber.Ctx) error {
+	var req struct {
+		IDs  []string `json:"ids"`
+		Hard bool     `json:"hard"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return wrapErrorStatus(c, fiber.StatusBadRequest, err, "请求体格式错误")
+	}
+	result, err := service.AudioSafeDeleteAssets(req.IDs, req.Hard)
+	if err != nil {
+		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "批量安全删除失败")
+	}
+	return c.JSON(result)
+}
+
+func AdminAudioAssetCleanupPreview(c *fiber.Ctx) error {
+	days := c.QueryInt("days", 30)
+	if days <= 0 {
+		return wrapErrorStatus(c, fiber.StatusBadRequest, nil, "清理周期必须大于 0 天")
+	}
+	filters := service.AdminAudioAssetFilters{
+		Query:      strings.TrimSpace(c.Query("query")),
+		QueryField: strings.TrimSpace(c.Query("queryField")),
+		SortBy:     strings.TrimSpace(c.Query("sortBy")),
+		SortOrder:  strings.TrimSpace(c.Query("sortOrder")),
+		Page:       1,
+		PageSize:   c.QueryInt("pageSize", 100),
+	}
+	if scope := strings.TrimSpace(c.Query("scope")); scope != "" && scope != "all" {
+		filters.Scope = model.AudioAssetScope(scope)
+	}
+	if worldID := strings.TrimSpace(c.Query("worldId")); worldID != "" {
+		filters.WorldID = &worldID
+	}
+	if creatorID := strings.TrimSpace(c.Query("creatorId")); creatorID != "" {
+		filters.CreatorID = &creatorID
+	}
+	preview, err := service.AdminAudioPreviewUnusedAssets(days, filters)
+	if err != nil {
+		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "读取清理预览失败")
+	}
+	return c.JSON(preview)
+}
+
+func AdminAudioAssetCleanupExecute(c *fiber.Ctx) error {
+	var req struct {
+		Days       int                   `json:"days"`
+		Hard       bool                  `json:"hard"`
+		Query      string                `json:"query"`
+		QueryField string                `json:"queryField"`
+		SortBy     string                `json:"sortBy"`
+		SortOrder  string                `json:"sortOrder"`
+		Scope      model.AudioAssetScope `json:"scope"`
+		WorldID    *string               `json:"worldId"`
+		CreatorID  *string               `json:"creatorId"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return wrapErrorStatus(c, fiber.StatusBadRequest, err, "请求体格式错误")
+	}
+	if req.Days <= 0 {
+		return wrapErrorStatus(c, fiber.StatusBadRequest, nil, "清理周期必须大于 0 天")
+	}
+	result, err := service.AdminAudioCleanupUnusedAssets(req.Days, service.AdminAudioAssetFilters{
+		Query:      strings.TrimSpace(req.Query),
+		QueryField: strings.TrimSpace(req.QueryField),
+		SortBy:     strings.TrimSpace(req.SortBy),
+		SortOrder:  strings.TrimSpace(req.SortOrder),
+		Scope:      req.Scope,
+		WorldID:    req.WorldID,
+		CreatorID:  req.CreatorID,
+		Page:       1,
+		PageSize:   1000,
+	}, req.Hard)
+	if err != nil {
+		return wrapErrorStatus(c, fiber.StatusInternalServerError, err, "执行清理失败")
+	}
+	return c.JSON(result)
 }
 
 type audioSceneRequest struct {
@@ -973,6 +1142,21 @@ func queryFloatSlice(c *fiber.Ctx, keys ...string) []float64 {
 		}
 	}
 	return result
+}
+
+func queryOptionalBool(c *fiber.Ctx, key string) (bool, bool) {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return false, false
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes":
+		return true, true
+	case "0", "false", "no":
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 func parseOptionalString(value string) *string {

--- a/api/character_card_template.go
+++ b/api/character_card_template.go
@@ -51,7 +51,16 @@ func mapCharacterCardTemplateError(err error) (int, string) {
 func CharacterCardTemplateList(c *fiber.Ctx) error {
 	user := getCurUser(c)
 	sheetType := c.Query("sheetType")
-	items, err := service.CharacterCardTemplateList(user.ID, sheetType)
+	worldID := strings.TrimSpace(c.Query("worldId"))
+	var (
+		items any
+		err error
+	)
+	if worldID != "" {
+		items, err = service.CharacterCardTemplateListWithWorld(user.ID, worldID, sheetType)
+	} else {
+		items, err = service.CharacterCardTemplateList(user.ID, sheetType)
+	}
 	if err != nil {
 		status, msg := mapCharacterCardTemplateError(err)
 		return c.Status(status).JSON(fiber.Map{"error": msg})

--- a/api/character_remark.go
+++ b/api/character_remark.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"time"
 	"unicode/utf8"
 
 	"sealchat/model"
@@ -25,12 +26,14 @@ type characterRemarkSnapshotPayload struct {
 
 type characterRemarkCache struct {
 	sync.RWMutex
-	items map[string]map[string]*protocol.CharacterRemarkEventPayload
+	items     map[string]map[string]*protocol.CharacterRemarkEventPayload
+	revisions map[string]map[string]int64
 }
 
 func newCharacterRemarkCache() *characterRemarkCache {
 	return &characterRemarkCache{
-		items: map[string]map[string]*protocol.CharacterRemarkEventPayload{},
+		items:     map[string]map[string]*protocol.CharacterRemarkEventPayload{},
+		revisions: map[string]map[string]int64{},
 	}
 }
 
@@ -45,20 +48,51 @@ func (c *characterRemarkCache) upsert(channelID string, payload *protocol.Charac
 		channelMap = map[string]*protocol.CharacterRemarkEventPayload{}
 		c.items[channelID] = channelMap
 	}
+	revisionMap, ok := c.revisions[channelID]
+	if !ok || revisionMap == nil {
+		revisionMap = map[string]int64{}
+		c.revisions[channelID] = revisionMap
+	}
+	lastRevision := revisionMap[payload.IdentityID]
+	if payload.Revision > 0 {
+		if payload.Revision < lastRevision {
+			return
+		}
+		revisionMap[payload.IdentityID] = payload.Revision
+	} else {
+		payload.Revision = lastRevision
+	}
 	channelMap[payload.IdentityID] = &protocol.CharacterRemarkEventPayload{
 		IdentityID: payload.IdentityID,
 		UserID:     payload.UserID,
 		Content:    payload.Content,
+		Revision:   payload.Revision,
 		Action:     "update",
 	}
 }
 
 func (c *characterRemarkCache) remove(channelID, identityID string) {
+	c.removeWithRevision(channelID, identityID, 0)
+}
+
+func (c *characterRemarkCache) removeWithRevision(channelID, identityID string, revision int64) {
 	if c == nil || channelID == "" || identityID == "" {
 		return
 	}
 	c.Lock()
 	defer c.Unlock()
+	revisionMap, ok := c.revisions[channelID]
+	if !ok || revisionMap == nil {
+		revisionMap = map[string]int64{}
+		c.revisions[channelID] = revisionMap
+	}
+	lastRevision := revisionMap[identityID]
+	if revision > 0 {
+		if revision < lastRevision {
+			return
+		}
+		revisionMap[identityID] = revision
+	}
 	channelMap, ok := c.items[channelID]
 	if !ok || channelMap == nil {
 		return
@@ -67,6 +101,26 @@ func (c *characterRemarkCache) remove(channelID, identityID string) {
 	if len(channelMap) == 0 {
 		delete(c.items, channelID)
 	}
+}
+
+func (c *characterRemarkCache) nextRevision(channelID, identityID string) int64 {
+	if c == nil || channelID == "" || identityID == "" {
+		return 0
+	}
+	c.Lock()
+	defer c.Unlock()
+	revisionMap, ok := c.revisions[channelID]
+	if !ok || revisionMap == nil {
+		revisionMap = map[string]int64{}
+		c.revisions[channelID] = revisionMap
+	}
+	now := time.Now().UnixMilli()
+	lastRevision := revisionMap[identityID]
+	if lastRevision >= now {
+		now = lastRevision + 1
+	}
+	revisionMap[identityID] = now
+	return now
 }
 
 func (c *characterRemarkCache) snapshot(channelID string) []*protocol.CharacterRemarkEventPayload {
@@ -88,6 +142,7 @@ func (c *characterRemarkCache) snapshot(channelID string) []*protocol.CharacterR
 			IdentityID: item.IdentityID,
 			UserID:     item.UserID,
 			Content:    item.Content,
+			Revision:   item.Revision,
 			Action:     "update",
 		})
 	}
@@ -140,11 +195,13 @@ func apiCharacterRemarkBroadcast(ctx *ChatContext, data *characterRemarkBroadcas
 	if err != nil {
 		return nil, err
 	}
+	revision := characterRemarkState.nextRevision(channelID, identityID)
 	if action == "clear" || shouldClear {
-		characterRemarkState.remove(channelID, identityID)
+		characterRemarkState.removeWithRevision(channelID, identityID, revision)
 		broadcastCharacterRemarkEvent(ctx, channelID, &protocol.CharacterRemarkEventPayload{
 			IdentityID: identityID,
 			UserID:     ctx.User.ID,
+			Revision:   revision,
 			Action:     "clear",
 		})
 		return map[string]any{"ok": true}, nil
@@ -153,6 +210,7 @@ func apiCharacterRemarkBroadcast(ctx *ChatContext, data *characterRemarkBroadcas
 		IdentityID: identityID,
 		UserID:     ctx.User.ID,
 		Content:    content,
+		Revision:   revision,
 		Action:     "update",
 	}
 	characterRemarkState.upsert(channelID, payload)

--- a/api/chat_api_message.go
+++ b/api/chat_api_message.go
@@ -3138,7 +3138,7 @@ func apiMessageUpdate(ctx *ChatContext, data *struct {
 	updates["edited_by_user_name"] = editorUserName
 	msg.EditedByUserID = ctx.User.ID
 	msg.EditedByUserName = editorUserName
-	err = db.Model(&model.MessageModel{}).Where("id = ?", msg.ID).Updates(updates).Error
+	err = model.MessageUpdate(msg.ID, updates)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sticky_note.go
+++ b/api/sticky_note.go
@@ -159,6 +159,118 @@ func canViewStickyNote(note *model.StickyNoteModel, userID string) bool {
 	}
 }
 
+func listConnectedStickyNoteUserIDs(channelID string) []string {
+	if channelID == "" {
+		return nil
+	}
+	userConnMap := getUserConnInfoMap()
+	if userConnMap == nil {
+		return nil
+	}
+	userIDs := make([]string, 0)
+	seen := make(map[string]struct{})
+	userConnMap.Range(func(userID string, connMap *utils.SyncMap[*WsSyncConn, *ConnInfo]) bool {
+		userID = strings.TrimSpace(userID)
+		if userID == "" {
+			return true
+		}
+		if _, exists := seen[userID]; exists {
+			return true
+		}
+		connected := false
+		connMap.Range(func(_ *WsSyncConn, info *ConnInfo) bool {
+			if info != nil && info.ChannelId == channelID {
+				connected = true
+				return false
+			}
+			return true
+		})
+		if connected {
+			seen[userID] = struct{}{}
+			userIDs = append(userIDs, userID)
+		}
+		return true
+	})
+	return userIDs
+}
+
+func buildStickyNoteVisibilityTransitionRecipients(userIDs []string, previousNote, currentNote *model.StickyNoteModel) (visibleNow []string, removed []string) {
+	seen := make(map[string]struct{}, len(userIDs))
+	for _, rawUserID := range userIDs {
+		userID := strings.TrimSpace(rawUserID)
+		if userID == "" {
+			continue
+		}
+		if _, exists := seen[userID]; exists {
+			continue
+		}
+		seen[userID] = struct{}{}
+		wasVisible := canViewStickyNote(previousNote, userID)
+		isVisible := canViewStickyNote(currentNote, userID)
+		if isVisible {
+			visibleNow = append(visibleNow, userID)
+			continue
+		}
+		if wasVisible {
+			removed = append(removed, userID)
+		}
+	}
+	return visibleNow, removed
+}
+
+func buildStickyNoteDeletePayload(channelID string, previousNote, currentNote *model.StickyNoteModel) *protocol.StickyNoteEventPayload {
+	base := previousNote
+	if base == nil {
+		base = currentNote
+	}
+	note := &protocol.StickyNote{ChannelID: channelID}
+	if base != nil {
+		note.ID = base.ID
+		if base.ChannelID != "" {
+			note.ChannelID = base.ChannelID
+		}
+	}
+	return &protocol.StickyNoteEventPayload{
+		Note:   note,
+		Action: "delete",
+	}
+}
+
+func broadcastStickyNoteToVisibleUsers(channelID string, eventType protocol.EventName, action string, currentNote *model.StickyNoteModel) {
+	if currentNote == nil {
+		return
+	}
+	recipients, _ := buildStickyNoteVisibilityTransitionRecipients(listConnectedStickyNoteUserIDs(channelID), nil, currentNote)
+	if len(recipients) == 0 {
+		return
+	}
+	BroadcastStickyNoteToUsers(recipients, eventType, &protocol.StickyNoteEventPayload{
+		Note:   currentNote.ToProtocolType(),
+		Action: action,
+	})
+}
+
+func broadcastStickyNoteUpdateTransition(channelID string, previousNote, currentNote *model.StickyNoteModel) {
+	recipients, removed := buildStickyNoteVisibilityTransitionRecipients(listConnectedStickyNoteUserIDs(channelID), previousNote, currentNote)
+	if len(recipients) > 0 && currentNote != nil {
+		BroadcastStickyNoteToUsers(recipients, protocol.EventStickyNoteUpdated, &protocol.StickyNoteEventPayload{
+			Note:   currentNote.ToProtocolType(),
+			Action: "update",
+		})
+	}
+	if len(removed) > 0 {
+		BroadcastStickyNoteToUsers(removed, protocol.EventStickyNoteDeleted, buildStickyNoteDeletePayload(channelID, previousNote, currentNote))
+	}
+}
+
+func broadcastStickyNoteDeleteToVisibleUsers(channelID string, previousNote *model.StickyNoteModel) {
+	_, removed := buildStickyNoteVisibilityTransitionRecipients(listConnectedStickyNoteUserIDs(channelID), previousNote, nil)
+	if len(removed) == 0 {
+		return
+	}
+	BroadcastStickyNoteToUsers(removed, protocol.EventStickyNoteDeleted, buildStickyNoteDeletePayload(channelID, previousNote, nil))
+}
+
 func loadStickyNoteForResponse(noteID string) (*model.StickyNoteModel, error) {
 	note, err := model.StickyNoteGet(noteID)
 	if err != nil {
@@ -298,10 +410,7 @@ func apiChannelStickyNoteCreate(c *fiber.Ctx) error {
 	note.Creator = user
 
 	// WebSocket 广播
-	go BroadcastStickyNoteToChannel(channelID, protocol.EventStickyNoteCreated, &protocol.StickyNoteEventPayload{
-		Note:   note.ToProtocolType(),
-		Action: "create",
-	})
+	go broadcastStickyNoteToVisibleUsers(channelID, protocol.EventStickyNoteCreated, "create", note)
 
 	return c.JSON(fiber.Map{"note": note.ToProtocolType()})
 }
@@ -488,19 +597,13 @@ func apiChannelStickyNoteMigrate(c *fiber.Ctx) error {
 	for targetID, cloned := range copiedByTarget {
 		for _, note := range cloned {
 			note.LoadCreator()
-			BroadcastStickyNoteToChannel(targetID, protocol.EventStickyNoteCreated, &protocol.StickyNoteEventPayload{
-				Note:   note.ToProtocolType(),
-				Action: "create",
-			})
+			broadcastStickyNoteToVisibleUsers(targetID, protocol.EventStickyNoteCreated, "create", note)
 		}
 	}
 
 	if mode == "move" {
 		for _, note := range selected {
-			BroadcastStickyNoteToChannel(channelID, protocol.EventStickyNoteDeleted, &protocol.StickyNoteEventPayload{
-				Note:   &protocol.StickyNote{ID: note.ID, ChannelID: channelID},
-				Action: "delete",
-			})
+			broadcastStickyNoteDeleteToVisibleUsers(channelID, note)
 		}
 	}
 
@@ -584,10 +687,7 @@ func apiStickyNoteEditLockAcquire(c *fiber.Ctx) error {
 		return c.Status(409).JSON(fiber.Map{"error": "note is being edited", "note": lockedNote.ToProtocolType()})
 	}
 
-	go BroadcastStickyNoteToChannel(lockedNote.ChannelID, protocol.EventStickyNoteUpdated, &protocol.StickyNoteEventPayload{
-		Note:   lockedNote.ToProtocolType(),
-		Action: "update",
-	})
+	go broadcastStickyNoteToVisibleUsers(lockedNote.ChannelID, protocol.EventStickyNoteUpdated, "update", lockedNote)
 	return c.JSON(fiber.Map{"note": lockedNote.ToProtocolType()})
 }
 
@@ -638,10 +738,7 @@ func apiStickyNoteEditLockRelease(c *fiber.Ctx) error {
 		return c.Status(404).JSON(fiber.Map{"error": "note not found"})
 	}
 	if result.RowsAffected > 0 {
-		go BroadcastStickyNoteToChannel(updatedNote.ChannelID, protocol.EventStickyNoteUpdated, &protocol.StickyNoteEventPayload{
-			Note:   updatedNote.ToProtocolType(),
-			Action: "update",
-		})
+		go broadcastStickyNoteToVisibleUsers(updatedNote.ChannelID, protocol.EventStickyNoteUpdated, "update", updatedNote)
 	}
 	return c.JSON(fiber.Map{"note": updatedNote.ToProtocolType()})
 }
@@ -706,6 +803,7 @@ func apiStickyNoteUpdateRest(c *fiber.Ctx) error {
 			}
 		}
 	}
+	previousNote := *note
 
 	updates := map[string]interface{}{
 		"updated_at": now,
@@ -771,10 +869,7 @@ func apiStickyNoteUpdateRest(c *fiber.Ctx) error {
 	note, _ = loadStickyNoteForResponse(noteID)
 
 	// 广播更新事件
-	go BroadcastStickyNoteToChannel(note.ChannelID, protocol.EventStickyNoteUpdated, &protocol.StickyNoteEventPayload{
-		Note:   note.ToProtocolType(),
-		Action: "update",
-	})
+	go broadcastStickyNoteUpdateTransition(note.ChannelID, &previousNote, note)
 
 	return c.JSON(fiber.Map{"note": note.ToProtocolType()})
 }
@@ -819,10 +914,7 @@ func apiStickyNoteDeleteRest(c *fiber.Ctx) error {
 	}
 
 	// 广播删除事件
-	go BroadcastStickyNoteToChannel(channelID, protocol.EventStickyNoteDeleted, &protocol.StickyNoteEventPayload{
-		Note:   &protocol.StickyNote{ID: noteID, ChannelID: channelID},
-		Action: "delete",
-	})
+	go broadcastStickyNoteDeleteToVisibleUsers(channelID, note)
 
 	return c.JSON(fiber.Map{"success": true})
 }

--- a/api/world_character_card_template.go
+++ b/api/world_character_card_template.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+
+	"sealchat/service"
+)
+
+func WorldCharacterCardTemplateShareHandler(c *fiber.Ctx) error {
+	user := getCurUser(c)
+	if user == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"message": "未登录"})
+	}
+	worldID := strings.TrimSpace(c.Params("worldId"))
+	templateID := strings.TrimSpace(c.Params("templateId"))
+	if worldID == "" || templateID == "" {
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"message": "参数错误"})
+	}
+	if err := service.WorldCharacterCardTemplateShare(worldID, templateID, user.ID); err != nil {
+		switch {
+		case err == service.ErrWorldPermission:
+			return c.Status(http.StatusForbidden).JSON(fiber.Map{"message": "无权共享模板"})
+		default:
+			return c.Status(http.StatusBadRequest).JSON(fiber.Map{"message": err.Error()})
+		}
+	}
+	return c.JSON(fiber.Map{"success": true})
+}
+
+func WorldCharacterCardTemplateUnshareHandler(c *fiber.Ctx) error {
+	user := getCurUser(c)
+	if user == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"message": "未登录"})
+	}
+	worldID := strings.TrimSpace(c.Params("worldId"))
+	templateID := strings.TrimSpace(c.Params("templateId"))
+	if worldID == "" || templateID == "" {
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"message": "参数错误"})
+	}
+	if err := service.WorldCharacterCardTemplateUnshare(worldID, templateID, user.ID); err != nil {
+		switch {
+		case err == service.ErrWorldPermission:
+			return c.Status(http.StatusForbidden).JSON(fiber.Map{"message": "无权取消共享模板"})
+		default:
+			return c.Status(http.StatusBadRequest).JSON(fiber.Map{"message": err.Error()})
+		}
+	}
+	return c.JSON(fiber.Map{"success": true})
+}

--- a/model/announcement.go
+++ b/model/announcement.go
@@ -52,6 +52,7 @@ type AnnouncementModel struct {
 	Status        AnnouncementStatus        `json:"status" gorm:"size:16;default:'draft';index"`
 	IsPinned      bool                      `json:"isPinned" gorm:"default:false;index"`
 	PinOrder      int                       `json:"pinOrder" gorm:"default:0;index"`
+	ShowInTicker  bool                      `json:"showInTicker" gorm:"default:false;index"`
 	PopupMode     AnnouncementPopupMode     `json:"popupMode" gorm:"size:24;default:'none'"`
 	ReminderScope AnnouncementReminderScope `json:"reminderScope" gorm:"size:24;default:'lobby_only'"`
 	RequireAck    bool                      `json:"requireAck" gorm:"default:false"`

--- a/model/audio.go
+++ b/model/audio.go
@@ -102,6 +102,8 @@ type AudioAsset struct {
 	Visibility      AudioAssetVisibility        `json:"visibility" gorm:"type:varchar(16)"`
 	CreatedBy       string                      `json:"createdBy" gorm:"index"`
 	UpdatedBy       string                      `json:"updatedBy"`
+	LastAccessedAt  *time.Time                  `json:"lastAccessedAt"`
+	AccessCount     int64                       `json:"accessCount" gorm:"not null;default:0"`
 	Variants        JSONList[AudioAssetVariant] `json:"variants" gorm:"type:json"`
 	TranscodeStatus AudioTranscodeStatus        `json:"transcodeStatus" gorm:"type:varchar(16);default:'ready'"`
 	Scope           AudioAssetScope             `json:"scope" gorm:"type:varchar(16);index;default:'common'"`

--- a/model/channel_identity.go
+++ b/model/channel_identity.go
@@ -316,7 +316,55 @@ func ChannelIdentityOptionListActive(channelID string) ([]*ChannelIdentityOption
 	if err != nil {
 		return nil, err
 	}
-	return append(options, extras...), nil
+	options = append(options, extras...)
+	sortChannelIdentityOptionsByMode(channelID, options)
+	return options, nil
+}
+
+func sortChannelIdentityOptionsByMode(channelID string, options []*ChannelIdentityOption) {
+	channelID = strings.TrimSpace(channelID)
+	if channelID == "" || len(options) <= 1 {
+		return
+	}
+
+	modeConfigs, err := ChannelIdentityModeConfigListByChannelTx(db, channelID)
+	if err != nil || len(modeConfigs) == 0 {
+		return
+	}
+
+	icIDs := make(map[string]struct{}, len(modeConfigs))
+	oocIDs := make(map[string]struct{}, len(modeConfigs))
+	for _, config := range modeConfigs {
+		if id := strings.TrimSpace(config.ICIdentityID); id != "" {
+			icIDs[id] = struct{}{}
+		}
+		if id := strings.TrimSpace(config.OOCIdentityID); id != "" {
+			oocIDs[id] = struct{}{}
+		}
+	}
+
+	weightOf := func(identityID string) int {
+		identityID = strings.TrimSpace(identityID)
+		if identityID == "" {
+			return 2
+		}
+		if _, ok := icIDs[identityID]; ok {
+			return 0
+		}
+		if _, ok := oocIDs[identityID]; ok {
+			return 1
+		}
+		return 2
+	}
+
+	sort.SliceStable(options, func(i, j int) bool {
+		leftWeight := weightOf(options[i].ID)
+		rightWeight := weightOf(options[j].ID)
+		if leftWeight != rightWeight {
+			return leftWeight < rightWeight
+		}
+		return false
+	})
 }
 
 func fetchChannelIdentityIDsFromMessages(channelID string) (map[string]struct{}, error) {

--- a/model/db.go
+++ b/model/db.go
@@ -151,6 +151,7 @@ func DBInit(cfg *utils.AppConfig) {
 	db.AutoMigrate(&CharacterCardModel{})
 	db.AutoMigrate(&CharacterCardTemplateModel{})
 	db.AutoMigrate(&CharacterCardTemplateBindingModel{})
+	db.AutoMigrate(&WorldCharacterCardTemplateBindingModel{})
 	db.AutoMigrate(&CharacterCardAvatarBindingModel{})
 	db.AutoMigrate(&ChannelIdentityFolderModel{}, &ChannelIdentityFolderMemberModel{}, &ChannelIdentityFolderFavoriteModel{})
 	db.AutoMigrate(&GalleryCollection{}, &GalleryItem{})

--- a/model/message.go
+++ b/model/message.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -52,16 +53,16 @@ type MessageModel struct {
 	IsImported    bool       `json:"isImported" gorm:"default:false;index:idx_msg_imported"`
 	ImportJobID   string     `json:"importJobId" gorm:"size:100;index:idx_msg_import_job_id"`
 
-	SenderMemberName          string `json:"sender_member_name"` // 用户在当时的名字
-	SenderIdentityID          string `json:"sender_identity_id" gorm:"size:100"`
-	SenderIdentityVariantID   string `json:"sender_identity_variant_id" gorm:"size:100"`
-	SenderIdentityName        string `json:"sender_identity_name"`
-	SenderIdentityColor       string `json:"sender_identity_color"`
-	SenderIdentityAvatarID    string `json:"sender_identity_avatar_id"`
+	SenderMemberName          string                        `json:"sender_member_name"` // 用户在当时的名字
+	SenderIdentityID          string                        `json:"sender_identity_id" gorm:"size:100"`
+	SenderIdentityVariantID   string                        `json:"sender_identity_variant_id" gorm:"size:100"`
+	SenderIdentityName        string                        `json:"sender_identity_name"`
+	SenderIdentityColor       string                        `json:"sender_identity_color"`
+	SenderIdentityAvatarID    string                        `json:"sender_identity_avatar_id"`
 	SenderIdentityDecorations protocol.AvatarDecorationList `json:"sender_identity_decorations,omitempty" gorm:"serializer:json;column:sender_identity_decoration"`
-	SenderIdentityIsTemporary bool   `json:"sender_identity_is_temporary" gorm:"default:false"`
-	SenderRoleID              string `json:"sender_role_id" gorm:"size:100"`
-	MergedMessages            int    `json:"-" gorm:"-"`
+	SenderIdentityIsTemporary bool                          `json:"sender_identity_is_temporary" gorm:"default:false"`
+	SenderRoleID              string                        `json:"sender_role_id" gorm:"size:100"`
+	MergedMessages            int                           `json:"-" gorm:"-"`
 
 	User   *UserModel    `json:"user"`           // 嵌套 User 结构体
 	Member *MemberModel  `json:"member"`         // 嵌套 Member 结构体
@@ -76,6 +77,43 @@ type MessageModel struct {
 
 func (*MessageModel) TableName() string {
 	return "messages"
+}
+
+func MessageUpdate(id string, values map[string]any) error {
+	if len(values) == 0 {
+		return nil
+	}
+	if rawDecoration, ok := values["sender_identity_decoration"]; ok {
+		switch value := rawDecoration.(type) {
+		case nil:
+			values["sender_identity_decoration"] = nil
+		case protocol.AvatarDecorationList:
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				return err
+			}
+			values["sender_identity_decoration"] = string(encoded)
+		case []protocol.AvatarDecoration:
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				return err
+			}
+			values["sender_identity_decoration"] = string(encoded)
+		case *protocol.AvatarDecoration:
+			encoded, err := json.Marshal(protocol.AvatarDecorationList{*value})
+			if err != nil {
+				return err
+			}
+			values["sender_identity_decoration"] = string(encoded)
+		case protocol.AvatarDecoration:
+			encoded, err := json.Marshal(protocol.AvatarDecorationList{value})
+			if err != nil {
+				return err
+			}
+			values["sender_identity_decoration"] = string(encoded)
+		}
+	}
+	return db.Model(&MessageModel{}).Where("id = ?", id).Updates(values).Error
 }
 
 func (m *MessageModel) ToProtocolType2(channelData *protocol.Channel) *protocol.Message {

--- a/model/world_character_card_template_binding.go
+++ b/model/world_character_card_template_binding.go
@@ -1,0 +1,22 @@
+package model
+
+import "strings"
+
+type WorldCharacterCardTemplateBindingModel struct {
+	StringPKBaseModel
+	WorldID    string `json:"worldId" gorm:"size:100;uniqueIndex:idx_world_character_card_template_binding,priority:1;index"`
+	TemplateID string `json:"templateId" gorm:"size:100;uniqueIndex:idx_world_character_card_template_binding,priority:2;index"`
+	CreatedBy  string `json:"createdBy" gorm:"size:100"`
+	UpdatedBy  string `json:"updatedBy" gorm:"size:100"`
+}
+
+func (*WorldCharacterCardTemplateBindingModel) TableName() string {
+	return "world_character_card_template_bindings"
+}
+
+func (m *WorldCharacterCardTemplateBindingModel) Normalize() {
+	m.WorldID = strings.TrimSpace(m.WorldID)
+	m.TemplateID = strings.TrimSpace(m.TemplateID)
+	m.CreatedBy = strings.TrimSpace(m.CreatedBy)
+	m.UpdatedBy = strings.TrimSpace(m.UpdatedBy)
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -649,6 +649,7 @@ type CharacterRemarkEventPayload struct {
 	IdentityID string `json:"identityId,omitempty"`
 	UserID     string `json:"userId,omitempty"`
 	Content    string `json:"content,omitempty"`
+	Revision   int64  `json:"revision,omitempty"`
 	Action     string `json:"action,omitempty"` // update/clear
 }
 

--- a/service/announcement.go
+++ b/service/announcement.go
@@ -26,6 +26,7 @@ type AnnouncementInput struct {
 	Status        string `json:"status"`
 	IsPinned      bool   `json:"isPinned"`
 	PinOrder      int    `json:"pinOrder"`
+	ShowInTicker  bool   `json:"showInTicker"`
 	PopupMode     string `json:"popupMode"`
 	ReminderScope string `json:"reminderScope"`
 	RequireAck    bool   `json:"requireAck"`
@@ -36,6 +37,7 @@ type AnnouncementListOptions struct {
 	PageSize        int
 	IncludeAll      bool
 	IncludeArchived bool
+	ShowInTicker    *bool
 }
 
 type AnnouncementPendingOptions struct {
@@ -161,6 +163,7 @@ func normalizeAnnouncementInput(scopeType model.AnnouncementScopeType, input *An
 		input.PinOrder = 0
 	}
 	if scopeType == model.AnnouncementScopeWorld {
+		input.ShowInTicker = false
 		input.ReminderScope = string(model.AnnouncementReminderScopeLobbyOnly)
 		return nil
 	}
@@ -324,6 +327,9 @@ func listAnnouncements(scopeType model.AnnouncementScopeType, scopeID string, us
 	}
 	query := model.GetDB().Model(&model.AnnouncementModel{}).
 		Where("scope_type = ? AND scope_id = ?", scopeType, scopeID)
+	if scopeType == model.AnnouncementScopeLobby && opts.ShowInTicker != nil {
+		query = query.Where("show_in_ticker = ?", *opts.ShowInTicker)
+	}
 	if opts.IncludeArchived {
 		if !canEdit {
 			return nil, 0, false, ErrAnnouncementPermission
@@ -394,6 +400,7 @@ func AnnouncementCreate(scopeType, scopeID, actorID string, input AnnouncementIn
 		Status:        model.AnnouncementStatus(input.Status),
 		IsPinned:      input.IsPinned,
 		PinOrder:      input.PinOrder,
+		ShowInTicker:  input.ShowInTicker,
 		PopupMode:     model.AnnouncementPopupMode(input.PopupMode),
 		ReminderScope: model.AnnouncementReminderScope(input.ReminderScope),
 		RequireAck:    input.RequireAck,
@@ -449,6 +456,7 @@ func AnnouncementUpdate(scopeType, scopeID, announcementID, actorID string, inpu
 		"status":         input.Status,
 		"is_pinned":      input.IsPinned,
 		"pin_order":      input.PinOrder,
+		"show_in_ticker": input.ShowInTicker,
 		"popup_mode":     input.PopupMode,
 		"reminder_scope": input.ReminderScope,
 		"require_ack":    input.RequireAck,

--- a/service/announcement_test.go
+++ b/service/announcement_test.go
@@ -1,0 +1,170 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"sealchat/model"
+	"sealchat/pm"
+	"sealchat/utils"
+)
+
+func initAnnouncementTestDB(t *testing.T) {
+	t.Helper()
+	cfg := &utils.AppConfig{
+		DSN: fmt.Sprintf("file:announcement-test-%s?mode=memory&cache=shared", utils.NewID()),
+		SQLite: utils.SQLiteConfig{
+			EnableWAL:       false,
+			TxLockImmediate: false,
+			ReadConnections: 1,
+			OptimizeOnInit:  false,
+		},
+	}
+	model.DBInit(cfg)
+	pm.Init()
+}
+
+func createAnnouncementTestUser(t *testing.T, id string) *model.UserModel {
+	t.Helper()
+	user := &model.UserModel{
+		StringPKBaseModel: model.StringPKBaseModel{ID: id},
+		Username:          "user_" + id,
+		Nickname:          "nick_" + id,
+		Password:          "pw",
+		Salt:              "salt",
+	}
+	if err := model.GetDB().Create(user).Error; err != nil {
+		t.Fatalf("create user %s failed: %v", id, err)
+	}
+	return user
+}
+
+func createAnnouncementTestWorld(t *testing.T, worldID, ownerID string) {
+	t.Helper()
+	world := &model.WorldModel{
+		StringPKBaseModel: model.StringPKBaseModel{ID: worldID},
+		Name:              "World " + worldID,
+		OwnerID:           ownerID,
+		Status:            "active",
+		Visibility:        model.WorldVisibilityPublic,
+	}
+	if err := model.GetDB().Create(world).Error; err != nil {
+		t.Fatalf("create world %s failed: %v", worldID, err)
+	}
+}
+
+func createAnnouncementTestWorldMember(t *testing.T, worldID, userID, role string) {
+	t.Helper()
+	member := &model.WorldMemberModel{
+		StringPKBaseModel: model.StringPKBaseModel{ID: "wm-" + userID + "-" + utils.NewIDWithLength(6)},
+		WorldID:           worldID,
+		UserID:            userID,
+		Role:              role,
+		JoinedAt:          time.Now(),
+	}
+	if err := model.GetDB().Create(member).Error; err != nil {
+		t.Fatalf("create world member %s failed: %v", userID, err)
+	}
+}
+
+func grantAnnouncementSystemAdmin(t *testing.T, userID string) {
+	t.Helper()
+	if _, err := model.UserRoleLink([]string{"sys-admin"}, []string{userID}); err != nil {
+		t.Fatalf("grant sys-admin to %s failed: %v", userID, err)
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func TestAnnouncementCreateWorldScopeForcesTickerOff(t *testing.T) {
+	initAnnouncementTestDB(t)
+
+	owner := createAnnouncementTestUser(t, "world-owner")
+	createAnnouncementTestWorld(t, "world-ticker", owner.ID)
+	createAnnouncementTestWorldMember(t, "world-ticker", owner.ID, model.WorldRoleOwner)
+
+	item, err := AnnouncementCreate("world", "world-ticker", owner.ID, AnnouncementInput{
+		Title:         "世界公告",
+		Content:       "内容",
+		ContentFormat: "plain",
+		Status:        "published",
+		ShowInTicker:  true,
+	})
+	if err != nil {
+		t.Fatalf("create world announcement failed: %v", err)
+	}
+
+	if item.ShowInTicker {
+		t.Fatalf("world announcement showInTicker=%v, want false", item.ShowInTicker)
+	}
+
+	stored, err := loadAnnouncementOrError(item.ID)
+	if err != nil {
+		t.Fatalf("load announcement failed: %v", err)
+	}
+	if stored.ShowInTicker {
+		t.Fatalf("stored world announcement showInTicker=%v, want false", stored.ShowInTicker)
+	}
+}
+
+func TestAnnouncementListLobbyTickerFilterOnlyReturnsPublishedTickerItems(t *testing.T) {
+	initAnnouncementTestDB(t)
+
+	admin := createAnnouncementTestUser(t, "lobby-admin")
+	reader := createAnnouncementTestUser(t, "lobby-reader")
+	grantAnnouncementSystemAdmin(t, admin.ID)
+
+	if _, err := AnnouncementCreate("lobby", "", admin.ID, AnnouncementInput{
+		Title:         "普通大厅公告",
+		Content:       "不进广播区",
+		ContentFormat: "plain",
+		Status:        "published",
+		ShowInTicker:  false,
+	}); err != nil {
+		t.Fatalf("create non ticker announcement failed: %v", err)
+	}
+
+	expected, err := AnnouncementCreate("lobby", "", admin.ID, AnnouncementInput{
+		Title:         "广播公告",
+		Content:       "进入广播区",
+		ContentFormat: "plain",
+		Status:        "published",
+		ShowInTicker:  true,
+	})
+	if err != nil {
+		t.Fatalf("create ticker announcement failed: %v", err)
+	}
+
+	if _, err := AnnouncementCreate("lobby", "", admin.ID, AnnouncementInput{
+		Title:         "草稿广播公告",
+		Content:       "不应出现在发布列表",
+		ContentFormat: "plain",
+		Status:        "draft",
+		ShowInTicker:  true,
+	}); err != nil {
+		t.Fatalf("create draft ticker announcement failed: %v", err)
+	}
+
+	items, total, err := AnnouncementList("lobby", "", reader.ID, AnnouncementListOptions{
+		ShowInTicker: boolPtr(true),
+	})
+	if err != nil {
+		t.Fatalf("list ticker announcements failed: %v", err)
+	}
+
+	if total != 1 {
+		t.Fatalf("ticker total=%d, want 1", total)
+	}
+	if len(items) != 1 {
+		t.Fatalf("ticker len=%d, want 1", len(items))
+	}
+	if items[0].ID != expected.ID {
+		t.Fatalf("ticker id=%s, want %s", items[0].ID, expected.ID)
+	}
+	if !items[0].ShowInTicker {
+		t.Fatalf("ticker item showInTicker=%v, want true", items[0].ShowInTicker)
+	}
+}

--- a/service/audio_domain.go
+++ b/service/audio_domain.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"sealchat/model"
 	"sealchat/utils"
@@ -90,10 +91,14 @@ type AudioBulkDeleteFailure struct {
 }
 
 type AudioBulkDeleteResult struct {
-	SuccessIDs   []string                 `json:"successIds"`
-	Failed       []AudioBulkDeleteFailure `json:"failed"`
-	SuccessCount int                      `json:"successCount"`
-	FailedCount  int                      `json:"failedCount"`
+	SuccessIDs                   []string                 `json:"successIds"`
+	Failed                       []AudioBulkDeleteFailure `json:"failed"`
+	SuccessCount                 int                      `json:"successCount"`
+	FailedCount                  int                      `json:"failedCount"`
+	DetachedSceneCount           int                      `json:"detachedSceneCount"`
+	DetachedPlaybackStateCount   int                      `json:"detachedPlaybackStateCount"`
+	DetachedReferencedAssetCount int                      `json:"detachedReferencedAssetCount"`
+	PlaybackScopeLabels          []string                 `json:"playbackScopeLabels,omitempty"`
 }
 
 type AdminAudioFilterOption struct {
@@ -111,11 +116,25 @@ type AdminAudioAssetListResult struct {
 }
 
 type AdminAudioCleanupPreview struct {
-	ThresholdBefore   time.Time                 `json:"thresholdBefore"`
-	TotalCandidates   int                       `json:"totalCandidates"`
-	SafeCandidates    int                       `json:"safeCandidates"`
-	ReferencedSkipped int                       `json:"referencedSkipped"`
-	Items             []AdminAudioAssetListItem `json:"items"`
+	ThresholdBefore            time.Time                 `json:"thresholdBefore"`
+	TotalCandidates            int                       `json:"totalCandidates"`
+	SafeCandidates             int                       `json:"safeCandidates"`
+	ReferencedSkipped          int                       `json:"referencedSkipped"`
+	DirectDeleteCandidates     int                       `json:"directDeleteCandidates"`
+	DetachThenDeleteCandidates int                       `json:"detachThenDeleteCandidates"`
+	Items                      []AdminAudioAssetListItem `json:"items"`
+}
+
+type AudioDeleteImpact struct {
+	DetachedSceneCount         int      `json:"detachedSceneCount"`
+	DetachedPlaybackStateCount int      `json:"detachedPlaybackStateCount"`
+	SceneNames                 []string `json:"sceneNames,omitempty"`
+	PlaybackScopeLabels        []string `json:"playbackScopeLabels,omitempty"`
+}
+
+type audioPlaybackDetachResult struct {
+	States      []*model.AudioPlaybackState
+	ScopeLabels []string
 }
 
 type AudioImportPreviewItem struct {
@@ -1277,19 +1296,8 @@ func AudioDeleteAsset(id string, hard bool) error {
 	if err != nil {
 		return err
 	}
-	svc := GetAudioService()
-	if svc != nil {
-		svc.removeAssetObject(asset.StorageType, asset.ObjectKey)
-		for _, variant := range asset.Variants {
-			svc.removeAssetObject(variant.StorageType, variant.ObjectKey)
-		}
-	}
-	if hard {
-		return model.GetDB().Unscoped().Delete(&model.AudioAsset{}, "id = ?", id).Error
-	}
-	return model.GetDB().Model(&model.AudioAsset{}).
-		Where("id = ?", id).
-		Updates(map[string]interface{}{"deleted_at": time.Now()}).Error
+	audioDeleteAssetObjects(asset)
+	return audioDeleteAssetRecordTx(model.GetDB(), id, hard)
 }
 
 func AudioTouchAssetAccess(assetID string) error {
@@ -1398,6 +1406,374 @@ func AudioSafeDeleteAssets(ids []string, hard bool) (*AudioBulkDeleteResult, err
 	result.SuccessCount = len(result.SuccessIDs)
 	result.FailedCount = len(result.Failed)
 	return result, nil
+}
+
+func AdminAudioDeleteAsset(id string, hard bool) (*AudioDeleteImpact, error) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return nil, errors.New("asset id is empty")
+	}
+	var deletedAsset *model.AudioAsset
+	impact := &AudioDeleteImpact{}
+	err := model.GetDB().Transaction(func(tx *gorm.DB) error {
+		asset, sceneImpact, playbackImpact, txErr := audioDetachAndDeleteAssetTx(tx, trimmed, hard)
+		if txErr != nil {
+			return txErr
+		}
+		deletedAsset = asset
+		impact = mergeDeleteImpact(sceneImpact, playbackImpact)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if deletedAsset != nil {
+		audioDeleteAssetObjects(deletedAsset)
+	}
+	return impact, nil
+}
+
+func AdminAudioDeleteAssets(ids []string, hard bool) (*AudioBulkDeleteResult, error) {
+	result := &AudioBulkDeleteResult{
+		SuccessIDs: make([]string, 0, len(ids)),
+		Failed:     make([]AudioBulkDeleteFailure, 0),
+	}
+	seen := map[string]struct{}{}
+	for _, rawID := range ids {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		impact, err := AdminAudioDeleteAsset(id, hard)
+		if err != nil {
+			failure := AudioBulkDeleteFailure{
+				AssetID: id,
+				Reason:  err.Error(),
+			}
+			var referencedErr *AudioAssetReferencedError
+			if errors.As(err, &referencedErr) {
+				summary := referencedErr.Summary
+				failure.UsageSummary = &summary
+			}
+			result.Failed = append(result.Failed, failure)
+			continue
+		}
+		result.SuccessIDs = append(result.SuccessIDs, id)
+		if impact != nil {
+			result.DetachedSceneCount += impact.DetachedSceneCount
+			result.DetachedPlaybackStateCount += impact.DetachedPlaybackStateCount
+			if impact.DetachedSceneCount > 0 || impact.DetachedPlaybackStateCount > 0 {
+				result.DetachedReferencedAssetCount++
+			}
+			if len(impact.PlaybackScopeLabels) > 0 {
+				result.PlaybackScopeLabels = appendUniqueStrings(result.PlaybackScopeLabels, impact.PlaybackScopeLabels...)
+			}
+		}
+	}
+	result.SuccessCount = len(result.SuccessIDs)
+	result.FailedCount = len(result.Failed)
+	return result, nil
+}
+
+func audioDetachAndDeleteAssetTx(tx *gorm.DB, id string, hard bool) (*model.AudioAsset, *AudioDeleteImpact, *AudioDeleteImpact, error) {
+	var asset model.AudioAsset
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ? AND deleted_at IS NULL", id).
+		First(&asset).Error; err != nil {
+		return nil, nil, nil, err
+	}
+	sceneImpact, err := detachAssetFromScenesTx(tx, asset.ID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	playbackImpact, err := detachAssetFromPlaybackStatesTx(tx, asset.ID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	summary, err := audioGetAssetUsageSummaryTx(tx, asset.ID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if summary.Referenced {
+		return nil, nil, nil, &AudioAssetReferencedError{Summary: summary}
+	}
+	if err := audioDeleteAssetRecordTx(tx, asset.ID, hard); err != nil {
+		return nil, nil, nil, err
+	}
+	return &asset, sceneImpact, playbackImpact, nil
+}
+
+func audioDeleteAssetRecordTx(tx *gorm.DB, id string, hard bool) error {
+	if hard {
+		return tx.Unscoped().Delete(&model.AudioAsset{}, "id = ?", id).Error
+	}
+	return tx.Model(&model.AudioAsset{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{"deleted_at": time.Now()}).Error
+}
+
+func audioDeleteAssetObjects(asset *model.AudioAsset) {
+	if asset == nil {
+		return
+	}
+	svc := GetAudioService()
+	if svc == nil {
+		return
+	}
+	svc.removeAssetObject(asset.StorageType, asset.ObjectKey)
+	for _, variant := range asset.Variants {
+		svc.removeAssetObject(variant.StorageType, variant.ObjectKey)
+	}
+}
+
+func mergeDeleteImpact(sceneImpact, playbackImpact *AudioDeleteImpact) *AudioDeleteImpact {
+	result := &AudioDeleteImpact{}
+	if sceneImpact != nil {
+		result.DetachedSceneCount += sceneImpact.DetachedSceneCount
+		result.SceneNames = append(result.SceneNames, sceneImpact.SceneNames...)
+	}
+	if playbackImpact != nil {
+		result.DetachedPlaybackStateCount += playbackImpact.DetachedPlaybackStateCount
+		result.PlaybackScopeLabels = append(result.PlaybackScopeLabels, playbackImpact.PlaybackScopeLabels...)
+	}
+	return result
+}
+
+func detachAssetFromScenesTx(tx *gorm.DB, assetID string) (*AudioDeleteImpact, error) {
+	impact := &AudioDeleteImpact{}
+	var scenes []*model.AudioScene
+	if err := tx.Find(&scenes).Error; err != nil {
+		return nil, err
+	}
+	for _, scene := range scenes {
+		if scene == nil {
+			continue
+		}
+		updatedTracks, changed := detachAssetFromSceneTracks(scene.Tracks, assetID)
+		if !changed {
+			continue
+		}
+		scene.Tracks = updatedTracks
+		scene.UpdatedAt = time.Now()
+		if err := tx.Model(&model.AudioScene{}).Where("id = ?", scene.ID).Updates(map[string]interface{}{
+			"tracks":      scene.Tracks,
+			"updated_at":  scene.UpdatedAt,
+			"description": scene.Description,
+		}).Error; err != nil {
+			return nil, err
+		}
+		impact.DetachedSceneCount++
+		if name := strings.TrimSpace(scene.Name); name != "" {
+			impact.SceneNames = append(impact.SceneNames, name)
+		}
+	}
+	return impact, nil
+}
+
+func detachAssetFromPlaybackStatesTx(tx *gorm.DB, assetID string) (*AudioDeleteImpact, error) {
+	impact := &AudioDeleteImpact{}
+	var states []*model.AudioPlaybackState
+	if err := tx.Find(&states).Error; err != nil {
+		return nil, err
+	}
+	for _, state := range states {
+		if state == nil {
+			continue
+		}
+		updatedTracks, changed := detachAssetFromPlaybackTracks(state.Tracks, assetID)
+		if !changed {
+			continue
+		}
+		state.Tracks = updatedTracks
+		if allPlaybackTracksIdle(state.Tracks) {
+			state.IsPlaying = false
+			state.Position = 0
+		}
+		state.UpdatedAt = time.Now()
+		state.Revision += 1
+		if state.CapturedAtMs <= 0 {
+			state.CapturedAtMs = state.UpdatedAt.UnixMilli()
+		} else {
+			state.CapturedAtMs = state.UpdatedAt.UnixMilli()
+		}
+		if err := tx.Model(&model.AudioPlaybackState{}).Where("channel_id = ?", state.ChannelID).Updates(map[string]interface{}{
+			"tracks":          state.Tracks,
+			"is_playing":      state.IsPlaying,
+			"position":        state.Position,
+			"updated_at":      state.UpdatedAt,
+			"revision":        state.Revision,
+			"captured_at_ms":  state.CapturedAtMs,
+			"loop_enabled":    state.LoopEnabled,
+			"playback_rate":   state.PlaybackRate,
+			"updated_by":      state.UpdatedBy,
+			"scene_id":        state.SceneID,
+			"world_playback_enabled": state.WorldPlaybackEnabled,
+		}).Error; err != nil {
+			return nil, err
+		}
+		syncPlaybackRuntimeState(state)
+		impact.DetachedPlaybackStateCount++
+		if label := strings.TrimSpace(state.ChannelID); label != "" {
+			impact.PlaybackScopeLabels = append(impact.PlaybackScopeLabels, label)
+		}
+	}
+	return impact, nil
+}
+
+func audioGetAssetUsageSummaryTx(tx *gorm.DB, assetID string) (AudioAssetUsageSummary, error) {
+	trimmed := strings.TrimSpace(assetID)
+	if trimmed == "" {
+		return AudioAssetUsageSummary{}, errors.New("asset id is empty")
+	}
+	summary := AudioAssetUsageSummary{}
+	var scenes []*model.AudioScene
+	if err := tx.Find(&scenes).Error; err != nil {
+		return summary, err
+	}
+	for _, scene := range scenes {
+		if scene == nil || !sceneReferencesAsset(scene.Tracks, trimmed) {
+			continue
+		}
+		summary.SceneRefCount++
+		if name := strings.TrimSpace(scene.Name); name != "" {
+			summary.SceneNames = append(summary.SceneNames, name)
+		}
+	}
+	var playbackStates []*model.AudioPlaybackState
+	if err := tx.Find(&playbackStates).Error; err != nil {
+		return summary, err
+	}
+	for _, state := range playbackStates {
+		if state == nil || !playbackStateReferencesAsset(state.Tracks, trimmed) {
+			continue
+		}
+		summary.PlaybackStateRefCount++
+		if label := strings.TrimSpace(state.ChannelID); label != "" {
+			summary.PlaybackScopeLabels = append(summary.PlaybackScopeLabels, label)
+		}
+	}
+	summary.Referenced = summary.SceneRefCount > 0 || summary.PlaybackStateRefCount > 0
+	return summary, nil
+}
+
+func detachAssetFromSceneTracks(tracks model.JSONList[model.AudioSceneTrack], assetID string) (model.JSONList[model.AudioSceneTrack], bool) {
+	result := make([]model.AudioSceneTrack, 0, len(tracks))
+	changed := false
+	for _, track := range tracks {
+		next := track
+		if next.AssetID != nil && strings.TrimSpace(*next.AssetID) == assetID {
+			next.AssetID = nil
+			changed = true
+		}
+		filtered, removed := removeAssetIDFromList(next.PlaylistAssetIDs, assetID)
+		if removed {
+			next.PlaylistAssetIDs = filtered
+			changed = true
+		}
+		if len(next.PlaylistAssetIDs) == 0 {
+			next.PlaylistIndex = 0
+		} else if next.PlaylistIndex >= len(next.PlaylistAssetIDs) {
+			next.PlaylistIndex = len(next.PlaylistAssetIDs) - 1
+		}
+		result = append(result, next)
+	}
+	return model.JSONList[model.AudioSceneTrack](result), changed
+}
+
+func detachAssetFromPlaybackTracks(tracks model.JSONList[model.AudioTrackState], assetID string) (model.JSONList[model.AudioTrackState], bool) {
+	result := make([]model.AudioTrackState, 0, len(tracks))
+	changed := false
+	for _, track := range tracks {
+		next := track
+		directDetached := false
+		if next.AssetID != nil && strings.TrimSpace(*next.AssetID) == assetID {
+			next.AssetID = nil
+			directDetached = true
+			changed = true
+		}
+		filtered, removed := removeAssetIDFromList(next.PlaylistAssetIDs, assetID)
+		if removed {
+			next.PlaylistAssetIDs = filtered
+			changed = true
+		}
+		if len(next.PlaylistAssetIDs) == 0 {
+			next.PlaylistIndex = 0
+		} else if next.PlaylistIndex >= len(next.PlaylistAssetIDs) {
+			next.PlaylistIndex = len(next.PlaylistAssetIDs) - 1
+		}
+		if directDetached || (next.AssetID == nil && len(next.PlaylistAssetIDs) == 0) {
+			next.IsPlaying = false
+			next.Position = 0
+		}
+		result = append(result, next)
+	}
+	return model.JSONList[model.AudioTrackState](result), changed
+}
+
+func removeAssetIDFromList(ids []string, assetID string) ([]string, bool) {
+	if len(ids) == 0 {
+		return ids, false
+	}
+	filtered := make([]string, 0, len(ids))
+	removed := false
+	for _, id := range ids {
+		if strings.TrimSpace(id) == assetID {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, id)
+	}
+	return filtered, removed
+}
+
+func allPlaybackTracksIdle(tracks model.JSONList[model.AudioTrackState]) bool {
+	for _, track := range tracks {
+		if track.IsPlaying && track.AssetID != nil && strings.TrimSpace(*track.AssetID) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func syncPlaybackRuntimeState(state *model.AudioPlaybackState) {
+	if state == nil {
+		return
+	}
+	scopeType := AudioPlaybackScopeChannel
+	scopeID := strings.TrimSpace(state.ChannelID)
+	if strings.HasPrefix(scopeID, audioWorldScopeRowPrefix) {
+		scopeType = AudioPlaybackScopeWorld
+		scopeID = strings.TrimPrefix(scopeID, audioWorldScopeRowPrefix)
+	}
+	audioPlaybackRuntimeStore.Lock()
+	audioPlaybackRuntimeStore.states[playbackScopeKey(scopeType, scopeID)] = modelToRuntimeState(state, scopeType, scopeID)
+	audioPlaybackRuntimeStore.Unlock()
+}
+
+func appendUniqueStrings(base []string, values ...string) []string {
+	if len(values) == 0 {
+		return base
+	}
+	seen := make(map[string]struct{}, len(base))
+	for _, item := range base {
+		seen[item] = struct{}{}
+	}
+	for _, item := range values {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		base = append(base, trimmed)
+	}
+	return base
 }
 
 func AdminAudioListAssets(filters AdminAudioAssetFilters) (*AdminAudioAssetListResult, error) {
@@ -1636,11 +2012,13 @@ func AdminAudioPreviewUnusedAssets(days int, filters AdminAudioAssetFilters) (*A
 	}
 	for _, item := range list.Items {
 		preview.TotalCandidates++
+		preview.Items = append(preview.Items, item)
 		if item.SafeToDelete {
 			preview.SafeCandidates++
-			preview.Items = append(preview.Items, item)
+			preview.DirectDeleteCandidates++
 		} else {
 			preview.ReferencedSkipped++
+			preview.DetachThenDeleteCandidates++
 		}
 	}
 	return preview, nil
@@ -1658,11 +2036,9 @@ func AdminAudioCleanupUnusedAssets(days int, filters AdminAudioAssetFilters, har
 	}
 	ids := make([]string, 0, len(list.Items))
 	for _, item := range list.Items {
-		if item.SafeToDelete {
-			ids = append(ids, item.ID)
-		}
+		ids = append(ids, item.ID)
 	}
-	return AudioSafeDeleteAssets(ids, hard)
+	return AdminAudioDeleteAssets(ids, hard)
 }
 
 func buildAdminAudioAssetItems(assets []*model.AudioAsset) ([]AdminAudioAssetListItem, error) {

--- a/service/audio_domain.go
+++ b/service/audio_domain.go
@@ -44,6 +44,80 @@ type AudioAssetUpdateInput struct {
 	Variants    []model.AudioAssetVariant
 }
 
+type AudioAssetUsageSummary struct {
+	SceneRefCount         int      `json:"sceneRefCount"`
+	PlaybackStateRefCount int      `json:"playbackStateRefCount"`
+	SceneNames            []string `json:"sceneNames,omitempty"`
+	PlaybackScopeLabels   []string `json:"playbackScopeLabels,omitempty"`
+	Referenced            bool     `json:"referenced"`
+}
+
+type AudioAssetReferencedError struct {
+	Summary AudioAssetUsageSummary
+}
+
+func (e *AudioAssetReferencedError) Error() string {
+	return "audio asset is still referenced"
+}
+
+type AdminAudioAssetFilters struct {
+	Query         string
+	QueryField    string
+	Scope         model.AudioAssetScope
+	WorldID       *string
+	CreatorID     *string
+	Referenced    *bool
+	NeverAccessed *bool
+	InactiveDays  int
+	SortBy        string
+	SortOrder     string
+	Page          int
+	PageSize      int
+}
+
+type AdminAudioAssetListItem struct {
+	*model.AudioAsset
+	WorldName    string                 `json:"worldName"`
+	CreatorName  string                 `json:"creatorName"`
+	UsageSummary AudioAssetUsageSummary `json:"usageSummary"`
+	SafeToDelete bool                   `json:"safeToDelete"`
+}
+
+type AudioBulkDeleteFailure struct {
+	AssetID      string                  `json:"assetId"`
+	Reason       string                  `json:"reason"`
+	UsageSummary *AudioAssetUsageSummary `json:"usageSummary,omitempty"`
+}
+
+type AudioBulkDeleteResult struct {
+	SuccessIDs   []string                 `json:"successIds"`
+	Failed       []AudioBulkDeleteFailure `json:"failed"`
+	SuccessCount int                      `json:"successCount"`
+	FailedCount  int                      `json:"failedCount"`
+}
+
+type AdminAudioFilterOption struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+}
+
+type AdminAudioAssetListResult struct {
+	Items          []AdminAudioAssetListItem `json:"items"`
+	Page           int                       `json:"page"`
+	PageSize       int                       `json:"pageSize"`
+	Total          int64                     `json:"total"`
+	WorldOptions   []AdminAudioFilterOption  `json:"worldOptions"`
+	CreatorOptions []AdminAudioFilterOption  `json:"creatorOptions"`
+}
+
+type AdminAudioCleanupPreview struct {
+	ThresholdBefore   time.Time                 `json:"thresholdBefore"`
+	TotalCandidates   int                       `json:"totalCandidates"`
+	SafeCandidates    int                       `json:"safeCandidates"`
+	ReferencedSkipped int                       `json:"referencedSkipped"`
+	Items             []AdminAudioAssetListItem `json:"items"`
+}
+
 type AudioImportPreviewItem struct {
 	Path     string `json:"path"`
 	Name     string `json:"name"`
@@ -201,6 +275,22 @@ func (f *AudioAssetFilters) normalize() {
 	}
 	if f.PageSize <= 0 || f.PageSize > 500 {
 		f.PageSize = 200
+	}
+}
+
+func (f *AdminAudioAssetFilters) normalize() {
+	f.Query = strings.TrimSpace(f.Query)
+	f.QueryField = normalizeAdminAudioQueryField(f.QueryField)
+	f.SortBy = normalizeAdminAudioSortField(f.SortBy)
+	f.SortOrder = normalizeAdminAudioSortOrder(f.SortOrder)
+	if f.Page <= 0 {
+		f.Page = 1
+	}
+	if f.PageSize <= 0 || f.PageSize > 200 {
+		f.PageSize = 20
+	}
+	if f.InactiveDays < 0 {
+		f.InactiveDays = 0
 	}
 }
 
@@ -1200,6 +1290,576 @@ func AudioDeleteAsset(id string, hard bool) error {
 	return model.GetDB().Model(&model.AudioAsset{}).
 		Where("id = ?", id).
 		Updates(map[string]interface{}{"deleted_at": time.Now()}).Error
+}
+
+func AudioTouchAssetAccess(assetID string) error {
+	trimmed := strings.TrimSpace(assetID)
+	if trimmed == "" {
+		return errors.New("asset id is empty")
+	}
+	now := time.Now()
+	return model.GetDB().Model(&model.AudioAsset{}).
+		Where("id = ? AND deleted_at IS NULL", trimmed).
+		Updates(map[string]interface{}{
+			"last_accessed_at": &now,
+			"access_count":     gorm.Expr("access_count + 1"),
+			"updated_at":       now,
+		}).Error
+}
+
+func AudioGetAssetUsageSummary(assetID string) (AudioAssetUsageSummary, error) {
+	trimmed := strings.TrimSpace(assetID)
+	if trimmed == "" {
+		return AudioAssetUsageSummary{}, errors.New("asset id is empty")
+	}
+
+	summary := AudioAssetUsageSummary{}
+	var scenes []*model.AudioScene
+	if err := model.GetDB().Find(&scenes).Error; err != nil {
+		return summary, err
+	}
+	for _, scene := range scenes {
+		if scene == nil {
+			continue
+		}
+		if !sceneReferencesAsset(scene.Tracks, trimmed) {
+			continue
+		}
+		summary.SceneRefCount++
+		if name := strings.TrimSpace(scene.Name); name != "" {
+			summary.SceneNames = append(summary.SceneNames, name)
+		}
+	}
+
+	var playbackStates []*model.AudioPlaybackState
+	if err := model.GetDB().Find(&playbackStates).Error; err != nil {
+		return summary, err
+	}
+	for _, state := range playbackStates {
+		if state == nil {
+			continue
+		}
+		if !playbackStateReferencesAsset(state.Tracks, trimmed) {
+			continue
+		}
+		summary.PlaybackStateRefCount++
+		label := strings.TrimSpace(state.ChannelID)
+		if label != "" {
+			summary.PlaybackScopeLabels = append(summary.PlaybackScopeLabels, label)
+		}
+	}
+
+	summary.Referenced = summary.SceneRefCount > 0 || summary.PlaybackStateRefCount > 0
+	return summary, nil
+}
+
+func AudioSafeDeleteAsset(id string, hard bool) error {
+	summary, err := AudioGetAssetUsageSummary(id)
+	if err != nil {
+		return err
+	}
+	if summary.Referenced {
+		return &AudioAssetReferencedError{Summary: summary}
+	}
+	return AudioDeleteAsset(id, hard)
+}
+
+func AudioSafeDeleteAssets(ids []string, hard bool) (*AudioBulkDeleteResult, error) {
+	result := &AudioBulkDeleteResult{
+		SuccessIDs: make([]string, 0, len(ids)),
+		Failed:     make([]AudioBulkDeleteFailure, 0),
+	}
+	seen := map[string]struct{}{}
+	for _, rawID := range ids {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		if err := AudioSafeDeleteAsset(id, hard); err != nil {
+			failure := AudioBulkDeleteFailure{
+				AssetID: id,
+				Reason:  err.Error(),
+			}
+			var referencedErr *AudioAssetReferencedError
+			if errors.As(err, &referencedErr) {
+				summary := referencedErr.Summary
+				failure.UsageSummary = &summary
+				failure.Reason = "素材仍被引用，无法安全删除"
+			}
+			result.Failed = append(result.Failed, failure)
+			continue
+		}
+		result.SuccessIDs = append(result.SuccessIDs, id)
+	}
+	result.SuccessCount = len(result.SuccessIDs)
+	result.FailedCount = len(result.Failed)
+	return result, nil
+}
+
+func AdminAudioListAssets(filters AdminAudioAssetFilters) (*AdminAudioAssetListResult, error) {
+	filters.normalize()
+	db := model.GetDB()
+	q := db.Model(&model.AudioAsset{}).Where("deleted_at IS NULL")
+	if filters.Scope != "" {
+		q = q.Where("scope = ?", filters.Scope)
+	}
+	if filters.WorldID != nil && strings.TrimSpace(*filters.WorldID) != "" {
+		q = q.Where("world_id = ?", strings.TrimSpace(*filters.WorldID))
+	}
+	if filters.CreatorID != nil && strings.TrimSpace(*filters.CreatorID) != "" {
+		q = q.Where("created_by = ?", strings.TrimSpace(*filters.CreatorID))
+	}
+	if filters.NeverAccessed != nil {
+		if *filters.NeverAccessed {
+			q = q.Where("last_accessed_at IS NULL")
+		} else {
+			q = q.Where("last_accessed_at IS NOT NULL")
+		}
+	}
+	if filters.InactiveDays > 0 {
+		threshold := time.Now().Add(-time.Duration(filters.InactiveDays) * 24 * time.Hour)
+		q = q.Where("(last_accessed_at IS NULL OR last_accessed_at < ?)", threshold)
+	}
+
+	var assets []*model.AudioAsset
+	if err := q.Order("updated_at DESC").Find(&assets).Error; err != nil {
+		return nil, err
+	}
+	items, err := buildAdminAudioAssetItems(assets)
+	if err != nil {
+		return nil, err
+	}
+	items = filterAdminAudioAssetItemsByQuery(items, filters.Query, filters.QueryField)
+	if filters.Referenced != nil {
+		filtered := make([]AdminAudioAssetListItem, 0, len(items))
+		for _, item := range items {
+			if item.UsageSummary.Referenced == *filters.Referenced {
+				filtered = append(filtered, item)
+			}
+		}
+		items = filtered
+	}
+	sortAdminAudioAssetItems(items, filters.SortBy, filters.SortOrder)
+	total := int64(len(items))
+	start := (filters.Page - 1) * filters.PageSize
+	if start > len(items) {
+		start = len(items)
+	}
+	end := start + filters.PageSize
+	if end > len(items) {
+		end = len(items)
+	}
+	worldOptions, creatorOptions, err := buildAdminAudioFilterOptions(assets)
+	if err != nil {
+		return nil, err
+	}
+	return &AdminAudioAssetListResult{
+		Items:          items[start:end],
+		Page:           filters.Page,
+		PageSize:       filters.PageSize,
+		Total:          total,
+		WorldOptions:   worldOptions,
+		CreatorOptions: creatorOptions,
+	}, nil
+}
+
+func normalizeAdminAudioQueryField(value string) string {
+	switch strings.TrimSpace(value) {
+	case "", "all":
+		return "all"
+	case "name", "worldName", "creatorName", "scope":
+		return strings.TrimSpace(value)
+	default:
+		return "all"
+	}
+}
+
+func normalizeAdminAudioSortField(value string) string {
+	switch strings.TrimSpace(value) {
+	case "", "updatedAt":
+		return "updatedAt"
+	case "name", "scope", "worldName", "creatorName", "size", "lastAccessedAt":
+		return strings.TrimSpace(value)
+	default:
+		return "updatedAt"
+	}
+}
+
+func normalizeAdminAudioSortOrder(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "asc":
+		return "asc"
+	case "desc", "":
+		return "desc"
+	default:
+		return "desc"
+	}
+}
+
+func filterAdminAudioAssetItemsByQuery(items []AdminAudioAssetListItem, query, queryField string) []AdminAudioAssetListItem {
+	keyword := strings.ToLower(strings.TrimSpace(query))
+	if keyword == "" {
+		return items
+	}
+	filtered := make([]AdminAudioAssetListItem, 0, len(items))
+	for _, item := range items {
+		if adminAudioItemMatchesQuery(item, keyword, queryField) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func adminAudioItemMatchesQuery(item AdminAudioAssetListItem, keyword, queryField string) bool {
+	values := adminAudioItemQueryValues(item, queryField)
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(strings.TrimSpace(value)), keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+func adminAudioItemQueryValues(item AdminAudioAssetListItem, queryField string) []string {
+	switch queryField {
+	case "name":
+		return []string{item.Name, item.Description, strings.Join(item.Tags, " ")}
+	case "worldName":
+		return []string{item.WorldName, normalizeOptionalString(item.WorldID)}
+	case "creatorName":
+		return []string{item.CreatorName, item.CreatedBy}
+	case "scope":
+		return []string{string(item.Scope)}
+	default:
+		return []string{
+			item.Name,
+			item.Description,
+			strings.Join(item.Tags, " "),
+			item.WorldName,
+			normalizeOptionalString(item.WorldID),
+			item.CreatorName,
+			item.CreatedBy,
+			string(item.Scope),
+		}
+	}
+}
+
+func sortAdminAudioAssetItems(items []AdminAudioAssetListItem, sortBy, sortOrder string) {
+	desc := sortOrder != "asc"
+	sort.SliceStable(items, func(i, j int) bool {
+		left := items[i]
+		right := items[j]
+		var less bool
+		switch sortBy {
+		case "name":
+			less = strings.ToLower(left.Name) < strings.ToLower(right.Name)
+		case "scope":
+			less = strings.ToLower(string(left.Scope)) < strings.ToLower(string(right.Scope))
+		case "worldName":
+			less = strings.ToLower(left.WorldName) < strings.ToLower(right.WorldName)
+		case "creatorName":
+			less = strings.ToLower(left.CreatorName) < strings.ToLower(right.CreatorName)
+		case "size":
+			less = left.Size < right.Size
+		case "lastAccessedAt":
+			less = compareOptionalTime(left.LastAccessedAt, right.LastAccessedAt)
+		case "updatedAt":
+			fallthrough
+		default:
+			less = left.UpdatedAt.Before(right.UpdatedAt)
+		}
+		if desc {
+			return !less && !adminAudioItemEqualOnSort(left, right, sortBy)
+		}
+		return less && !adminAudioItemEqualOnSort(left, right, sortBy)
+	})
+}
+
+func adminAudioItemEqualOnSort(left, right AdminAudioAssetListItem, sortBy string) bool {
+	switch sortBy {
+	case "name":
+		return strings.EqualFold(left.Name, right.Name)
+	case "scope":
+		return strings.EqualFold(string(left.Scope), string(right.Scope))
+	case "worldName":
+		return strings.EqualFold(left.WorldName, right.WorldName)
+	case "creatorName":
+		return strings.EqualFold(left.CreatorName, right.CreatorName)
+	case "size":
+		return left.Size == right.Size
+	case "lastAccessedAt":
+		return optionalTimeEqual(left.LastAccessedAt, right.LastAccessedAt)
+	case "updatedAt":
+		fallthrough
+	default:
+		return left.UpdatedAt.Equal(right.UpdatedAt)
+	}
+}
+
+func compareOptionalTime(left, right *time.Time) bool {
+	if left == nil && right == nil {
+		return false
+	}
+	if left == nil {
+		return true
+	}
+	if right == nil {
+		return false
+	}
+	return left.Before(*right)
+}
+
+func optionalTimeEqual(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Equal(*right)
+}
+
+func AdminAudioPreviewUnusedAssets(days int, filters AdminAudioAssetFilters) (*AdminAudioCleanupPreview, error) {
+	filters.InactiveDays = days
+	filters.Page = 1
+	if filters.PageSize <= 0 {
+		filters.PageSize = 100
+	}
+	list, err := AdminAudioListAssets(filters)
+	if err != nil {
+		return nil, err
+	}
+	preview := &AdminAudioCleanupPreview{
+		ThresholdBefore: time.Now().Add(-time.Duration(days) * 24 * time.Hour),
+		Items:           make([]AdminAudioAssetListItem, 0),
+	}
+	for _, item := range list.Items {
+		preview.TotalCandidates++
+		if item.SafeToDelete {
+			preview.SafeCandidates++
+			preview.Items = append(preview.Items, item)
+		} else {
+			preview.ReferencedSkipped++
+		}
+	}
+	return preview, nil
+}
+
+func AdminAudioCleanupUnusedAssets(days int, filters AdminAudioAssetFilters, hard bool) (*AudioBulkDeleteResult, error) {
+	filters.InactiveDays = days
+	filters.Page = 1
+	if filters.PageSize <= 0 {
+		filters.PageSize = 1000
+	}
+	list, err := AdminAudioListAssets(filters)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(list.Items))
+	for _, item := range list.Items {
+		if item.SafeToDelete {
+			ids = append(ids, item.ID)
+		}
+	}
+	return AudioSafeDeleteAssets(ids, hard)
+}
+
+func buildAdminAudioAssetItems(assets []*model.AudioAsset) ([]AdminAudioAssetListItem, error) {
+	if len(assets) == 0 {
+		return []AdminAudioAssetListItem{}, nil
+	}
+	worldIDs := make([]string, 0)
+	userIDs := make([]string, 0)
+	worldSeen := map[string]struct{}{}
+	userSeen := map[string]struct{}{}
+	for _, asset := range assets {
+		if asset == nil {
+			continue
+		}
+		if asset.WorldID != nil {
+			worldID := strings.TrimSpace(*asset.WorldID)
+			if worldID != "" {
+				if _, ok := worldSeen[worldID]; !ok {
+					worldSeen[worldID] = struct{}{}
+					worldIDs = append(worldIDs, worldID)
+				}
+			}
+		}
+		userID := strings.TrimSpace(asset.CreatedBy)
+		if userID != "" {
+			if _, ok := userSeen[userID]; !ok {
+				userSeen[userID] = struct{}{}
+				userIDs = append(userIDs, userID)
+			}
+		}
+	}
+
+	worldNames := map[string]string{}
+	if len(worldIDs) > 0 {
+		var worlds []*model.WorldModel
+		if err := model.GetDB().Where("id IN ?", worldIDs).Find(&worlds).Error; err != nil {
+			return nil, err
+		}
+		for _, world := range worlds {
+			if world != nil {
+				worldNames[world.ID] = strings.TrimSpace(world.Name)
+			}
+		}
+	}
+
+	userNames := map[string]string{}
+	if len(userIDs) > 0 {
+		var users []*model.UserModel
+		if err := model.GetDB().Where("id IN ?", userIDs).Find(&users).Error; err != nil {
+			return nil, err
+		}
+		for _, user := range users {
+			if user == nil {
+				continue
+			}
+			name := strings.TrimSpace(user.Nickname)
+			if name == "" {
+				name = strings.TrimSpace(user.Username)
+			}
+			if name == "" {
+				name = user.ID
+			}
+			userNames[user.ID] = name
+		}
+	}
+
+	items := make([]AdminAudioAssetListItem, 0, len(assets))
+	for _, asset := range assets {
+		if asset == nil {
+			continue
+		}
+		usage, err := AudioGetAssetUsageSummary(asset.ID)
+		if err != nil {
+			return nil, err
+		}
+		worldName := ""
+		if asset.WorldID != nil {
+			worldName = worldNames[strings.TrimSpace(*asset.WorldID)]
+		}
+		items = append(items, AdminAudioAssetListItem{
+			AudioAsset:   asset,
+			WorldName:    worldName,
+			CreatorName:  userNames[strings.TrimSpace(asset.CreatedBy)],
+			UsageSummary: usage,
+			SafeToDelete: !usage.Referenced,
+		})
+	}
+	return items, nil
+}
+
+func buildAdminAudioFilterOptions(assets []*model.AudioAsset) ([]AdminAudioFilterOption, []AdminAudioFilterOption, error) {
+	worldOptionMap := map[string]string{}
+	creatorOptionMap := map[string]string{}
+	for _, asset := range assets {
+		if asset == nil {
+			continue
+		}
+		if asset.WorldID != nil {
+			worldID := strings.TrimSpace(*asset.WorldID)
+			if worldID != "" {
+				worldOptionMap[worldID] = worldID
+			}
+		}
+		userID := strings.TrimSpace(asset.CreatedBy)
+		if userID != "" {
+			creatorOptionMap[userID] = userID
+		}
+	}
+
+	worldIDs := make([]string, 0, len(worldOptionMap))
+	for id := range worldOptionMap {
+		worldIDs = append(worldIDs, id)
+	}
+	sort.Strings(worldIDs)
+	worldOptions := make([]AdminAudioFilterOption, 0, len(worldIDs))
+	if len(worldIDs) > 0 {
+		var worlds []*model.WorldModel
+		if err := model.GetDB().Where("id IN ?", worldIDs).Find(&worlds).Error; err != nil {
+			return nil, nil, err
+		}
+		worldNames := map[string]string{}
+		for _, world := range worlds {
+			if world != nil {
+				worldNames[world.ID] = strings.TrimSpace(world.Name)
+			}
+		}
+		for _, id := range worldIDs {
+			label := worldNames[id]
+			if label == "" {
+				label = id
+			}
+			worldOptions = append(worldOptions, AdminAudioFilterOption{Label: label, Value: id})
+		}
+	}
+
+	creatorIDs := make([]string, 0, len(creatorOptionMap))
+	for id := range creatorOptionMap {
+		creatorIDs = append(creatorIDs, id)
+	}
+	sort.Strings(creatorIDs)
+	creatorOptions := make([]AdminAudioFilterOption, 0, len(creatorIDs))
+	if len(creatorIDs) > 0 {
+		var users []*model.UserModel
+		if err := model.GetDB().Where("id IN ?", creatorIDs).Find(&users).Error; err != nil {
+			return nil, nil, err
+		}
+		userNames := map[string]string{}
+		for _, user := range users {
+			if user == nil {
+				continue
+			}
+			label := strings.TrimSpace(user.Nickname)
+			if label == "" {
+				label = strings.TrimSpace(user.Username)
+			}
+			if label == "" {
+				label = user.ID
+			}
+			userNames[user.ID] = label
+		}
+		for _, id := range creatorIDs {
+			label := userNames[id]
+			if label == "" {
+				label = id
+			}
+			creatorOptions = append(creatorOptions, AdminAudioFilterOption{Label: label, Value: id})
+		}
+	}
+	return worldOptions, creatorOptions, nil
+}
+
+func sceneReferencesAsset(tracks model.JSONList[model.AudioSceneTrack], assetID string) bool {
+	for _, track := range tracks {
+		if track.AssetID != nil && strings.TrimSpace(*track.AssetID) == assetID {
+			return true
+		}
+		for _, playlistAssetID := range track.PlaylistAssetIDs {
+			if strings.TrimSpace(playlistAssetID) == assetID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func playbackStateReferencesAsset(tracks model.JSONList[model.AudioTrackState], assetID string) bool {
+	for _, track := range tracks {
+		if track.AssetID != nil && strings.TrimSpace(*track.AssetID) == assetID {
+			return true
+		}
+		for _, playlistAssetID := range track.PlaylistAssetIDs {
+			if strings.TrimSpace(playlistAssetID) == assetID {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func AudioListFolders() ([]*AudioFolderNode, error) {

--- a/service/character_card_template.go
+++ b/service/character_card_template.go
@@ -65,7 +65,7 @@ func normalizeCharacterCardTemplateInput(input *CharacterCardTemplateInput) erro
 		return errors.New("模板名称长度需在100个字符以内")
 	}
 	if input.SheetType != "" && len([]rune(input.SheetType)) > 32 {
-		return errors.New("模板规制类型长度需在32个字符以内")
+		return errors.New("模板规则类型长度需在32个字符以内")
 	}
 	if input.Content == "" {
 		return errors.New("模板内容不能为空")
@@ -90,7 +90,7 @@ func normalizeCharacterCardTemplateUpdateInput(input *CharacterCardTemplateUpdat
 	if input.SheetType != nil {
 		sheetType := strings.TrimSpace(*input.SheetType)
 		if sheetType != "" && len([]rune(sheetType)) > 32 {
-			return errors.New("模板规制类型长度需在32个字符以内")
+			return errors.New("模板规则类型长度需在32个字符以内")
 		}
 		input.SheetType = &sheetType
 	}
@@ -209,7 +209,7 @@ func CharacterCardTemplateCreate(userID string, input *CharacterCardTemplateInpu
 		}
 		if input.IsSheetDefault {
 			if item.SheetType == "" {
-				return errors.New("设置规制默认模板时，sheetType 不能为空")
+				return errors.New("设置规则默认模板时，sheetType 不能为空")
 			}
 			if err := tx.Model(&model.CharacterCardTemplateModel{}).
 				Where("user_id = ?", userID).
@@ -265,7 +265,7 @@ func CharacterCardTemplateUpdate(userID string, templateID string, input *Charac
 		}
 		if input.IsSheetDefault != nil && *input.IsSheetDefault {
 			if strings.TrimSpace(nextSheetType) == "" {
-				return errors.New("设置规制默认模板时，sheetType 不能为空")
+				return errors.New("设置规则默认模板时，sheetType 不能为空")
 			}
 			if err := tx.Model(&model.CharacterCardTemplateModel{}).
 				Where("user_id = ?", userID).
@@ -336,7 +336,7 @@ func CharacterCardTemplateSetDefault(userID string, templateID string, scope str
 			}).Error
 		case CharacterCardTemplateDefaultScopeSheet:
 			if strings.TrimSpace(template.SheetType) == "" {
-				return errors.New("当前模板缺少 sheetType，无法设为规制默认模板")
+				return errors.New("当前模板缺少 sheetType，无法设为规则默认模板")
 			}
 			if err := tx.Model(&model.CharacterCardTemplateModel{}).
 				Where("user_id = ?", userID).

--- a/service/character_card_template.go
+++ b/service/character_card_template.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"sealchat/model"
+	"sealchat/pm"
 )
 
 const (
@@ -38,6 +39,16 @@ type CharacterCardTemplateBindingInput struct {
 	Mode             string
 	TemplateID       string
 	TemplateSnapshot string
+}
+
+type CharacterCardTemplateView struct {
+	*model.CharacterCardTemplateModel
+	Access                 string `json:"access"`
+	Readonly               bool   `json:"readonly"`
+	IsSharedToCurrentWorld bool   `json:"isSharedToCurrentWorld"`
+	SharedWorldID          string `json:"sharedWorldId,omitempty"`
+	SharedByUserID         string `json:"sharedByUserId,omitempty"`
+	SharedByNickname       string `json:"sharedByNickname,omitempty"`
 }
 
 func normalizeCharacterCardTemplateInput(input *CharacterCardTemplateInput) error {
@@ -98,6 +109,70 @@ func CharacterCardTemplateList(userID string, sheetType string) ([]*model.Charac
 		return nil, errors.New("缺少用户ID")
 	}
 	return model.CharacterCardTemplateList(userID, sheetType)
+}
+
+func CharacterCardTemplateListWithWorld(userID string, worldID string, sheetType string) ([]*CharacterCardTemplateView, error) {
+	if strings.TrimSpace(userID) == "" {
+		return nil, errors.New("缺少用户ID")
+	}
+	if strings.TrimSpace(worldID) == "" {
+		items, err := model.CharacterCardTemplateList(userID, sheetType)
+		if err != nil {
+			return nil, err
+		}
+		return buildOwnerTemplateViews(items, worldID), nil
+	}
+	if !IsWorldMember(worldID, userID) && !pm.CanWithSystemRole(userID, pm.PermModAdmin) {
+		return nil, ErrWorldPermission
+	}
+
+	ownerItems, err := model.CharacterCardTemplateList(userID, sheetType)
+	if err != nil {
+		return nil, err
+	}
+	sharedItems, err := listSharedTemplatesByWorld(worldID, sheetType)
+	if err != nil {
+		return nil, err
+	}
+
+	viewMap := map[string]*CharacterCardTemplateView{}
+	result := make([]*CharacterCardTemplateView, 0, len(ownerItems)+len(sharedItems))
+	for _, item := range ownerItems {
+		if item == nil || item.ID == "" {
+			continue
+		}
+		view := &CharacterCardTemplateView{
+			CharacterCardTemplateModel: item,
+			Access:                     "owner",
+			Readonly:                   false,
+		}
+		viewMap[item.ID] = view
+		result = append(result, view)
+	}
+	for _, item := range sharedItems {
+		if item == nil || item.ID == "" {
+			continue
+		}
+		if existing := viewMap[item.ID]; existing != nil {
+			existing.IsSharedToCurrentWorld = true
+			existing.SharedWorldID = worldID
+			existing.SharedByUserID = item.UserID
+			existing.SharedByNickname = resolveTemplateOwnerNickname(item.UserID)
+			continue
+		}
+		view := &CharacterCardTemplateView{
+			CharacterCardTemplateModel: item,
+			Access:                     "world_shared",
+			Readonly:                   item.UserID != userID,
+			IsSharedToCurrentWorld:     true,
+			SharedWorldID:              worldID,
+			SharedByUserID:             item.UserID,
+			SharedByNickname:           resolveTemplateOwnerNickname(item.UserID),
+		}
+		viewMap[item.ID] = view
+		result = append(result, view)
+	}
+	return result, nil
 }
 
 func CharacterCardTemplateGet(userID string, templateID string) (*model.CharacterCardTemplateModel, error) {
@@ -224,7 +299,6 @@ func CharacterCardTemplateDelete(userID string, templateID string) error {
 	}
 	return model.GetDB().Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&model.CharacterCardTemplateBindingModel{}).
-			Where("user_id = ?", userID).
 			Where("template_id = ?", template.ID).
 			Where("mode = ?", model.CharacterCardTemplateModeManaged).
 			Updates(map[string]any{
@@ -232,6 +306,10 @@ func CharacterCardTemplateDelete(userID string, templateID string) error {
 				"template_id":       "",
 				"template_snapshot": template.Content,
 			}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("template_id = ?", template.ID).
+			Delete(&model.WorldCharacterCardTemplateBindingModel{}).Error; err != nil {
 			return err
 		}
 		return tx.Where("id = ?", template.ID).Delete(&model.CharacterCardTemplateModel{}).Error
@@ -344,7 +422,21 @@ func CharacterCardTemplateBindingUpsert(userID string, input *CharacterCardTempl
 			}
 			return nil, err
 		}
-		if template.UserID != userID {
+		allowed := template.UserID == userID
+		if !allowed {
+			channel, err := model.ChannelGet(input.ChannelID)
+			if err != nil {
+				return nil, err
+			}
+			if channel != nil && strings.TrimSpace(channel.WorldID) != "" {
+				shared, err := IsCharacterCardTemplateSharedToWorld(template.ID, channel.WorldID)
+				if err != nil {
+					return nil, err
+				}
+				allowed = shared
+			}
+		}
+		if !allowed {
 			return nil, errors.New("无权绑定该模板")
 		}
 		if input.SheetType == "" {
@@ -385,4 +477,67 @@ func CharacterCardTemplateBindingUpsert(userID string, input *CharacterCardTempl
 		return nil, err
 	}
 	return item, nil
+}
+
+func buildOwnerTemplateViews(items []*model.CharacterCardTemplateModel, worldID string) []*CharacterCardTemplateView {
+	result := make([]*CharacterCardTemplateView, 0, len(items))
+	for _, item := range items {
+		if item == nil || item.ID == "" {
+			continue
+		}
+		isShared := false
+		if strings.TrimSpace(worldID) != "" {
+			shared, err := IsCharacterCardTemplateSharedToWorld(item.ID, worldID)
+			if err == nil {
+				isShared = shared
+			}
+		}
+		result = append(result, &CharacterCardTemplateView{
+			CharacterCardTemplateModel: item,
+			Access:                     "owner",
+			Readonly:                   false,
+			IsSharedToCurrentWorld:     isShared,
+			SharedWorldID:              worldID,
+			SharedByUserID:             item.UserID,
+			SharedByNickname:           resolveTemplateOwnerNickname(item.UserID),
+		})
+	}
+	return result
+}
+
+func listSharedTemplatesByWorld(worldID string, sheetType string) ([]*model.CharacterCardTemplateModel, error) {
+	templateIDs := []string{}
+	q := model.GetDB().Model(&model.WorldCharacterCardTemplateBindingModel{}).
+		Where("world_id = ?", strings.TrimSpace(worldID)).
+		Pluck("template_id", &templateIDs)
+	if q.Error != nil {
+		return nil, q.Error
+	}
+	if len(templateIDs) == 0 {
+		return []*model.CharacterCardTemplateModel{}, nil
+	}
+	var items []*model.CharacterCardTemplateModel
+	query := model.GetDB().Where("id IN ?", templateIDs)
+	if trimmed := strings.TrimSpace(sheetType); trimmed != "" {
+		query = query.Where("sheet_type = ?", trimmed)
+	}
+	if err := query.
+		Order("is_global_default desc").
+		Order("is_sheet_default desc").
+		Order("updated_at desc").
+		Find(&items).Error; err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func resolveTemplateOwnerNickname(userID string) string {
+	user := model.UserGet(strings.TrimSpace(userID))
+	if user == nil {
+		return ""
+	}
+	if trimmed := strings.TrimSpace(user.Nickname); trimmed != "" {
+		return trimmed
+	}
+	return strings.TrimSpace(user.Username)
 }

--- a/service/world.go
+++ b/service/world.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"golang.org/x/text/width"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -23,7 +24,7 @@ var (
 	ErrWorldInviteInvalid         = errors.New("world invite invalid")
 	ErrWorldMemberInvalid         = errors.New("world member invalid")
 	ErrWorldOwnerImmutable        = errors.New("world owner immutable")
-	ErrWorldDescriptionTooLong    = errors.New("世界简介不能超过30字")
+	ErrWorldDescriptionTooLong    = errors.New("世界简介不能超过100字（中文按1字、英文按0.5字计算）")
 	ErrWorldSystemDefaultProtect  = errors.New("系统默认世界不可删除")
 	ErrWorldObserverSlugInvalid   = errors.New("world observer slug invalid")
 	ErrWorldObserverSlugConflict  = errors.New("world observer slug conflict")
@@ -33,7 +34,10 @@ var (
 	ErrWorldDefaultDiceBotInvalid = errors.New("world default dice bot invalid")
 )
 
-const worldDescriptionMaxLength = 30
+const (
+	worldDescriptionMaxLength     = 100
+	worldDescriptionMaxWidthUnits = worldDescriptionMaxLength * 2
+)
 
 var worldObserverSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{3,31}$`)
 
@@ -52,26 +56,39 @@ type WorldCreateParams struct {
 }
 
 type WorldUpdateParams struct {
-	Name                       string
-	Description                string
-	Visibility                 string
-	Avatar                     string
-	EnforceMembership          *bool
-	AllowAdminEditMessages     *bool
+	Name                                  string
+	Description                           string
+	Visibility                            string
+	Avatar                                string
+	EnforceMembership                     *bool
+	AllowAdminEditMessages                *bool
 	AllowManageOtherUserChannelIdentities *bool
-	AllowMemberEditKeywords    *bool
-	StrictWhisperPrivacy       *bool
-	ChannelDefaultDiceMode     *string
-	ChannelDefaultBotID        *string
-	CharacterCardBadgeTemplate *string
+	AllowMemberEditKeywords               *bool
+	StrictWhisperPrivacy                  *bool
+	ChannelDefaultDiceMode                *string
+	ChannelDefaultBotID                   *string
+	CharacterCardBadgeTemplate            *string
 }
 
 func normalizeWorldDescription(desc string) (string, error) {
 	desc = strings.TrimSpace(desc)
-	if utf8.RuneCountInString(desc) > worldDescriptionMaxLength {
+	if countDisplayWidthUnits(desc) > worldDescriptionMaxWidthUnits {
 		return "", ErrWorldDescriptionTooLong
 	}
 	return desc, nil
+}
+
+func countDisplayWidthUnits(text string) int {
+	total := 0
+	for _, r := range text {
+		switch width.LookupRune(r).Kind() {
+		case width.EastAsianWide, width.EastAsianFullwidth:
+			total += 2
+		default:
+			total++
+		}
+	}
+	return total
 }
 
 func normalizeWorldBadgeTemplate(template string) (string, error) {

--- a/service/world_character_card_template.go
+++ b/service/world_character_card_template.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"sealchat/model"
+	"sealchat/pm"
+)
+
+func WorldCharacterCardTemplateShare(worldID, templateID, actorID string) error {
+	worldID = strings.TrimSpace(worldID)
+	templateID = strings.TrimSpace(templateID)
+	actorID = strings.TrimSpace(actorID)
+	if worldID == "" || templateID == "" || actorID == "" {
+		return ErrWorldPermission
+	}
+	if !pm.CanWithSystemRole(actorID, pm.PermModAdmin) && !IsWorldAdmin(worldID, actorID) {
+		return ErrWorldPermission
+	}
+	template, err := model.CharacterCardTemplateGetByID(templateID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("模板不存在")
+		}
+		return err
+	}
+	if template.ID == "" {
+		return errors.New("模板不存在")
+	}
+	if template.UserID != actorID && !pm.CanWithSystemRole(actorID, pm.PermModAdmin) {
+		return ErrWorldPermission
+	}
+	binding := &model.WorldCharacterCardTemplateBindingModel{
+		WorldID:    worldID,
+		TemplateID: templateID,
+		CreatedBy:  actorID,
+		UpdatedBy:  actorID,
+	}
+	binding.Normalize()
+	return model.GetDB().Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "world_id"}, {Name: "template_id"}},
+		DoUpdates: clause.Assignments(map[string]any{
+			"updated_by": actorID,
+			"updated_at": gorm.Expr("CURRENT_TIMESTAMP"),
+		}),
+	}).Create(binding).Error
+}
+
+func WorldCharacterCardTemplateUnshare(worldID, templateID, actorID string) error {
+	worldID = strings.TrimSpace(worldID)
+	templateID = strings.TrimSpace(templateID)
+	actorID = strings.TrimSpace(actorID)
+	if worldID == "" || templateID == "" || actorID == "" {
+		return ErrWorldPermission
+	}
+	if !pm.CanWithSystemRole(actorID, pm.PermModAdmin) && !IsWorldAdmin(worldID, actorID) {
+		return ErrWorldPermission
+	}
+	return model.GetDB().Where("world_id = ? AND template_id = ?", worldID, templateID).
+		Delete(&model.WorldCharacterCardTemplateBindingModel{}).Error
+}
+
+func IsCharacterCardTemplateSharedToWorld(templateID, worldID string) (bool, error) {
+	templateID = strings.TrimSpace(templateID)
+	worldID = strings.TrimSpace(worldID)
+	if templateID == "" || worldID == "" {
+		return false, nil
+	}
+	var count int64
+	if err := model.GetDB().Model(&model.WorldCharacterCardTemplateBindingModel{}).
+		Where("world_id = ? AND template_id = ?", worldID, templateID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/ui/components.d.ts
+++ b/ui/components.d.ts
@@ -118,5 +118,6 @@ declare module 'vue' {
     UserAvatarDecoration: typeof import('./src/components/user-avatar-decoration.vue')['default']
     UserLabel: typeof import('./src/components/UserLabel.vue')['default']
     UserLabelV: typeof import('./src/components/UserLabelV.vue')['default']
+    WorldLobbyAnnouncementTicker: typeof import('./src/components/announcement/WorldLobbyAnnouncementTicker.vue')['default']
   }
 }

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1851,28 +1851,35 @@ nav a:first-of-type {
 /* TransportBar 内部 Slider */
 :root[data-custom-theme='true'] .audio-drawer .transport-bar .n-slider,
 :root[data-custom-theme='true'] .n-drawer.audio-drawer .transport-bar .n-slider {
-  --n-rail-color: var(--sc-bg-surface) !important;
-  --n-rail-color-hover: var(--sc-bg-surface) !important;
-  --n-fill-color: var(--sc-accent, #3388de) !important;
+  --n-rail-color: rgba(148, 163, 184, 0.2) !important;
+  --n-rail-color-hover: rgba(148, 163, 184, 0.28) !important;
+  --n-fill-color: rgba(203, 213, 225, 0.72) !important;
   --n-fill-color-hover: var(--sc-accent, #3388de) !important;
-  --n-handle-color: var(--sc-accent, #3388de) !important;
+  --n-handle-color: rgba(255, 255, 255, 0.92) !important;
 }
 
 :root[data-custom-theme='true'] .audio-drawer .transport-bar .n-slider-rail,
 :root[data-custom-theme='true'] .n-drawer.audio-drawer .transport-bar .n-slider-rail {
-  background-color: var(--sc-bg-surface) !important;
+  background-color: rgba(148, 163, 184, 0.2) !important;
+  height: 4px !important;
 }
 
 :root[data-custom-theme='true'] .audio-drawer .transport-bar .n-slider-rail__fill,
 :root[data-custom-theme='true'] .n-drawer.audio-drawer .transport-bar .n-slider-rail__fill {
-  background-color: var(--sc-accent, #3388de) !important;
+  background-color: rgba(203, 213, 225, 0.72) !important;
 }
 
 :root[data-custom-theme='true'] .audio-drawer .transport-bar .n-slider-handle,
 :root[data-custom-theme='true'] .n-drawer.audio-drawer .transport-bar .n-slider-handle {
   --n-handle-color: #fff !important;
   background-color: #fff !important;
-  border-color: var(--sc-accent, #3388de) !important;
+  border-color: rgba(148, 163, 184, 0.45) !important;
+  transform: scale(0.82) !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .transport-bar__volume-slider:hover .n-slider-rail__fill,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .transport-bar__volume-slider:hover .n-slider-rail__fill {
+  background-color: var(--sc-accent, #3388de) !important;
 }
 
 /* TransportBar 内部 Select */
@@ -1939,28 +1946,78 @@ nav a:first-of-type {
 /* TrackMixerCard 内部 Slider */
 :root[data-custom-theme='true'] .audio-drawer .track-card .n-slider,
 :root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .n-slider {
-  --n-rail-color: var(--sc-bg-surface) !important;
-  --n-rail-color-hover: var(--sc-bg-surface) !important;
-  --n-fill-color: var(--sc-accent, #3388de) !important;
-  --n-fill-color-hover: var(--sc-accent, #3388de) !important;
-  --n-handle-color: var(--sc-accent, #3388de) !important;
+  --n-rail-color: rgba(148, 163, 184, 0.18) !important;
+  --n-rail-color-hover: rgba(148, 163, 184, 0.26) !important;
+  --n-fill-color: rgba(148, 163, 184, 0.72) !important;
+  --n-fill-color-hover: rgba(203, 213, 225, 0.84) !important;
+  --n-handle-color: rgba(255, 255, 255, 0.94) !important;
 }
 
 :root[data-custom-theme='true'] .audio-drawer .track-card .n-slider-rail,
 :root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .n-slider-rail {
-  background-color: var(--sc-bg-surface) !important;
+  background-color: rgba(148, 163, 184, 0.18) !important;
 }
 
 :root[data-custom-theme='true'] .audio-drawer .track-card .n-slider-rail__fill,
 :root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .n-slider-rail__fill {
-  background-color: var(--sc-accent, #3388de) !important;
+  background-color: rgba(148, 163, 184, 0.72) !important;
 }
 
 :root[data-custom-theme='true'] .audio-drawer .track-card .n-slider-handle,
 :root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .n-slider-handle {
   --n-handle-color: #fff !important;
   background-color: #fff !important;
-  border-color: var(--sc-accent, #3388de) !important;
+  border-color: rgba(148, 163, 184, 0.45) !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .track-card .track-card__progress-slider--primary .n-slider-rail,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .track-card__progress-slider--primary .n-slider-rail {
+  background-color: rgba(51, 65, 85, 0.92) !important;
+  height: 12px !important;
+  border-radius: 999px !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .track-card .track-card__progress-slider--primary .n-slider-rail__fill,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .track-card__progress-slider--primary .n-slider-rail__fill {
+  background-color: var(--sc-accent, #3388de) !important;
+  border-radius: 999px !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .track-card .track-card__progress-slider--primary .n-slider-handle,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .track-card__progress-slider--primary .n-slider-handle {
+  opacity: 0 !important;
+  transform: scale(0) !important;
+  border-width: 0 !important;
+  box-shadow: none !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .track-card .track-card__progress-slider--primary .n-slider-handle-wrapper,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .track-card__progress-slider--primary .n-slider-handle-wrapper {
+  width: 0 !important;
+  height: 0 !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .track-card .track-card__control-slider .n-slider-rail,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .track-card__control-slider .n-slider-rail {
+  background-color: rgba(148, 163, 184, 0.16) !important;
+  height: 4px !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .track-card .track-card__control-slider .n-slider-rail__fill,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .track-card__control-slider .n-slider-rail__fill {
+  background-color: rgba(203, 213, 225, 0.7) !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .track-card .track-card__control-slider .n-slider-handle,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .track-card__control-slider .n-slider-handle {
+  background-color: #fff !important;
+  border-color: rgba(148, 163, 184, 0.42) !important;
+  transform: scale(0.72) !important;
+}
+
+:root[data-custom-theme='true'] .audio-drawer .track-card .track-card__control-slider:hover .n-slider-rail__fill,
+:root[data-custom-theme='true'] .n-drawer.audio-drawer .track-card .track-card__control-slider:hover .n-slider-rail__fill {
+  background-color: rgba(148, 190, 255, 0.88) !important;
 }
 
 /* TrackMixerCard 内部 Select */

--- a/ui/src/assets/main.css
+++ b/ui/src/assets/main.css
@@ -23,8 +23,12 @@
   --chat-ooc-border: rgba(148, 163, 184, 0.35);
   --chat-archived-bg: rgba(248, 250, 252, 0.82);
   --chat-archived-border: rgba(203, 213, 225, 0.45);
-  --chat-whisper-bg: #eef2ff;
-  --chat-whisper-border: rgba(99, 102, 241, 0.35);
+  --chat-whisper-accent: #6366f1;
+  --chat-whisper-surface: rgba(99, 102, 241, 0.02);
+  --chat-whisper-bg: var(--chat-whisper-surface);
+  --chat-whisper-border: rgba(99, 102, 241, 0.12);
+  --chat-whisper-tag-bg: transparent;
+  --chat-whisper-tag-fg: color-mix(in srgb, var(--chat-whisper-accent) 78%, var(--chat-text-secondary, #475569));
   --chat-inline-code-bg: rgba(15, 23, 42, 0.08);
   --chat-inline-code-fg: #0f172a;
   --chat-inline-code-border: rgba(15, 23, 42, 0.12);
@@ -81,8 +85,12 @@
   --chat-ooc-border: rgba(255, 255, 255, 0.16);
   --chat-archived-bg: rgba(63, 63, 70, 0.45);
   --chat-archived-border: rgba(255, 255, 255, 0.12);
-  --chat-whisper-bg: #3b3248;
-  --chat-whisper-border: rgba(210, 197, 255, 0.35);
+  --chat-whisper-accent: #c4b5fd;
+  --chat-whisper-surface: rgba(196, 181, 253, 0.02);
+  --chat-whisper-bg: var(--chat-whisper-surface);
+  --chat-whisper-border: rgba(196, 181, 253, 0.14);
+  --chat-whisper-tag-bg: transparent;
+  --chat-whisper-tag-fg: color-mix(in srgb, var(--chat-whisper-accent) 74%, var(--chat-text-secondary, #b5b5c5));
   --chat-inline-code-bg: rgba(248, 250, 252, 0.14);
   --chat-inline-code-fg: #f4f4f5;
   --chat-inline-code-border: rgba(244, 244, 245, 0.24);
@@ -125,6 +133,12 @@
   --chat-inline-code-bg: color-mix(in srgb, var(--chat-text-primary, #0f172a) 12%, transparent);
   --chat-inline-code-fg: var(--chat-text-primary, #0f172a);
   --chat-inline-code-border: color-mix(in srgb, var(--chat-text-primary, #0f172a) 24%, transparent);
+  --chat-whisper-accent: var(--primary-color, #6366f1);
+  --chat-whisper-surface: color-mix(in srgb, var(--chat-whisper-accent) 2%, transparent);
+  --chat-whisper-bg: var(--chat-whisper-surface);
+  --chat-whisper-border: color-mix(in srgb, var(--chat-whisper-accent) 14%, transparent);
+  --chat-whisper-tag-bg: transparent;
+  --chat-whisper-tag-fg: color-mix(in srgb, var(--chat-whisper-accent) 78%, var(--chat-text-secondary, #475569));
 }
 
 :root[data-display-layout='compact'] {

--- a/ui/src/components/announcement/AnnouncementEditorModal.vue
+++ b/ui/src/components/announcement/AnnouncementEditorModal.vue
@@ -31,6 +31,7 @@ const form = ref<AnnouncementPayload>({
   status: 'published',
   isPinned: false,
   pinOrder: 0,
+  showInTicker: false,
   popupMode: 'none',
   reminderScope: 'lobby_only',
   requireAck: false,
@@ -40,6 +41,7 @@ const isEdit = computed(() => !!props.item?.id)
 const titleText = computed(() => isEdit.value ? '编辑公告' : '新建公告')
 const canRequireAck = computed(() => props.scopeType === 'world')
 const canChangeReminderScope = computed(() => props.scopeType === 'lobby')
+const canToggleTicker = computed(() => props.scopeType === 'lobby')
 const handleVisibleUpdate = (value: boolean) => emit('update:visible', value)
 const modalStyle = computed(() => (
   viewportWidth.value <= 640
@@ -78,6 +80,12 @@ const reminderScopeLabel = computed(() => {
   }
   return form.value.reminderScope === 'site_wide' ? '全站在线' : '仅大厅页'
 })
+const tickerLabel = computed(() => {
+  if (!canToggleTicker.value) {
+    return ''
+  }
+  return form.value.showInTicker ? '顶部广播' : '不进广播区'
+})
 const optionSummary = computed(() => {
   const parts = [
     `状态 ${statusLabel.value}`,
@@ -86,6 +94,9 @@ const optionSummary = computed(() => {
   ]
   if (canChangeReminderScope.value) {
     parts.push(`提醒 ${reminderScopeLabel.value}`)
+  }
+  if (canToggleTicker.value) {
+    parts.push(`广播 ${tickerLabel.value}`)
   }
   if (canRequireAck.value) {
     parts.push(form.value.requireAck ? '需成员确认' : '无需确认')
@@ -107,6 +118,7 @@ watch(
         status: item.status === 'archived' ? 'draft' : item.status,
         isPinned: item.isPinned,
         pinOrder: item.pinOrder || 0,
+        showInTicker: !!item.showInTicker,
         popupMode: item.popupMode || 'none',
         reminderScope: item.reminderScope || 'lobby_only',
         requireAck: item.requireAck,
@@ -120,6 +132,7 @@ watch(
       status: 'published',
       isPinned: false,
       pinOrder: 0,
+      showInTicker: false,
       popupMode: 'none',
       reminderScope: 'lobby_only',
       requireAck: false,
@@ -143,6 +156,7 @@ const handleSave = async () => {
   try {
     const payload: AnnouncementPayload = {
       ...form.value,
+      showInTicker: canToggleTicker.value ? form.value.showInTicker : false,
       reminderScope: canChangeReminderScope.value ? form.value.reminderScope : 'lobby_only',
       requireAck: canRequireAck.value ? form.value.requireAck : false,
     }
@@ -222,6 +236,10 @@ const handleSave = async () => {
               <n-radio-button value="lobby_only">仅大厅页</n-radio-button>
               <n-radio-button value="site_wide">全站在线</n-radio-button>
             </n-radio-group>
+          </div>
+          <div v-if="canToggleTicker" class="announcement-editor__tool announcement-editor__tool--switch">
+            <span class="announcement-editor__tool-label">顶部广播区</span>
+            <n-switch v-model:value="form.showInTicker" size="small" />
           </div>
           <div class="announcement-editor__tool announcement-editor__tool--switch">
             <span class="announcement-editor__tool-label">置顶</span>

--- a/ui/src/components/announcement/AnnouncementManagerModal.vue
+++ b/ui/src/components/announcement/AnnouncementManagerModal.vue
@@ -240,6 +240,13 @@ const shouldCollapseBody = (item: AnnouncementItem) => {
                   <n-space size="small" class="announcement-card__tags">
                     <n-tag v-if="item.status === 'draft'" size="small">草稿</n-tag>
                     <n-tag v-if="item.isPinned" size="small" type="warning">置顶</n-tag>
+                    <n-tag
+                      v-if="props.scopeType === 'lobby' && item.showInTicker"
+                      size="small"
+                      type="primary"
+                    >
+                      广播区
+                    </n-tag>
                     <n-tag v-if="item.popupMode === 'every_entry'" size="small" type="info">每次弹出</n-tag>
                     <n-tag v-else-if="item.popupMode === 'once_per_version'" size="small" type="info">每版本弹一次</n-tag>
                     <n-tag

--- a/ui/src/components/announcement/WorldLobbyAnnouncementTicker.vue
+++ b/ui/src/components/announcement/WorldLobbyAnnouncementTicker.vue
@@ -8,7 +8,7 @@ import { isTipTapJson, tiptapJsonToPlainText } from '@/utils/tiptap-render'
 import type { AnnouncementItem } from '@/models/announcement'
 
 const emit = defineEmits<{
-  (event: 'open-announcements'): void
+  (event: 'open-announcement', item: AnnouncementItem): void
 }>()
 
 const announcementStore = useAnnouncementStore()
@@ -92,11 +92,12 @@ const handleLobbyAnnouncementUpdated = () => {
   void load()
 }
 
-const openAnnouncements = () => {
-  if (!activeItem.value) {
+const openAnnouncement = () => {
+  const item = activeItem.value
+  if (!item) {
     return
   }
-  emit('open-announcements')
+  emit('open-announcement', item)
 }
 
 watch(canLoad, (value) => {
@@ -132,7 +133,7 @@ onBeforeUnmount(() => {
     type="button"
     class="world-lobby-ticker"
     :disabled="loading"
-    @click="openAnnouncements"
+    @click="openAnnouncement"
   >
     <span class="world-lobby-ticker__icon" aria-hidden="true">
       <n-icon size="14">

--- a/ui/src/components/announcement/WorldLobbyAnnouncementTicker.vue
+++ b/ui/src/components/announcement/WorldLobbyAnnouncementTicker.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { Speakerphone } from '@vicons/tabler'
+import { useAnnouncementStore } from '@/stores/announcement'
+import { useUserStore } from '@/stores/user'
+import { chatEvent } from '@/stores/chat'
+import { isTipTapJson, tiptapJsonToPlainText } from '@/utils/tiptap-render'
+import type { AnnouncementItem } from '@/models/announcement'
+
+const emit = defineEmits<{
+  (event: 'open-announcements'): void
+}>()
+
+const announcementStore = useAnnouncementStore()
+const user = useUserStore()
+
+const items = ref<AnnouncementItem[]>([])
+const loading = ref(false)
+const activeIndex = ref(0)
+
+let rotateTimer: ReturnType<typeof setInterval> | null = null
+
+const canLoad = computed(() => !!user.info.id)
+const activeItem = computed(() => {
+  if (!items.value.length) {
+    return null
+  }
+  const safeIndex = ((activeIndex.value % items.value.length) + items.value.length) % items.value.length
+  return items.value[safeIndex] || null
+})
+
+const normalizeSummary = (item: AnnouncementItem) => {
+  const raw = item.contentFormat === 'rich' && isTipTapJson(item.content)
+    ? tiptapJsonToPlainText(item.content)
+    : item.content || ''
+  return raw.replace(/\s+/g, ' ').trim().slice(0, 120)
+}
+
+const activeSummary = computed(() => {
+  const item = activeItem.value
+  if (!item) {
+    return ''
+  }
+  return normalizeSummary(item)
+})
+
+const clearRotateTimer = () => {
+  if (rotateTimer !== null) {
+    clearInterval(rotateTimer)
+    rotateTimer = null
+  }
+}
+
+const syncRotateTimer = () => {
+  clearRotateTimer()
+  if (typeof window === 'undefined' || items.value.length <= 1) {
+    return
+  }
+  rotateTimer = setInterval(() => {
+    activeIndex.value = (activeIndex.value + 1) % items.value.length
+  }, 5000)
+}
+
+const load = async () => {
+  if (!canLoad.value) {
+    items.value = []
+    activeIndex.value = 0
+    clearRotateTimer()
+    return
+  }
+  loading.value = true
+  try {
+    const data = await announcementStore.fetchLobbyList({
+      page: 1,
+      pageSize: 20,
+      showInTicker: true,
+    })
+    items.value = data.items || []
+    activeIndex.value = 0
+    syncRotateTimer()
+  } catch (error) {
+    console.warn('load lobby ticker announcements failed', error)
+    items.value = []
+    activeIndex.value = 0
+    clearRotateTimer()
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleLobbyAnnouncementUpdated = () => {
+  void load()
+}
+
+const openAnnouncements = () => {
+  if (!activeItem.value) {
+    return
+  }
+  emit('open-announcements')
+}
+
+watch(canLoad, (value) => {
+  if (value) {
+    void load()
+    return
+  }
+  items.value = []
+  activeIndex.value = 0
+  clearRotateTimer()
+}, { immediate: true })
+
+watch(() => items.value.length, () => {
+  if (activeIndex.value >= items.value.length) {
+    activeIndex.value = 0
+  }
+  syncRotateTimer()
+})
+
+onMounted(() => {
+  chatEvent.on('lobby-announcement-updated', handleLobbyAnnouncementUpdated as any)
+})
+
+onBeforeUnmount(() => {
+  chatEvent.off('lobby-announcement-updated', handleLobbyAnnouncementUpdated as any)
+  clearRotateTimer()
+})
+</script>
+
+<template>
+  <button
+    v-if="activeItem"
+    type="button"
+    class="world-lobby-ticker"
+    :disabled="loading"
+    @click="openAnnouncements"
+  >
+    <span class="world-lobby-ticker__icon" aria-hidden="true">
+      <n-icon size="14">
+        <Speakerphone />
+      </n-icon>
+    </span>
+    <div class="world-lobby-ticker__content">
+      <div class="world-lobby-ticker__line">
+        <span class="world-lobby-ticker__title">{{ activeItem.title }}</span>
+        <span v-if="activeSummary" class="world-lobby-ticker__separator">-</span>
+        <span v-if="activeSummary" class="world-lobby-ticker__summary">{{ activeSummary }}</span>
+      </div>
+    </div>
+    <div v-if="items.length > 1" class="world-lobby-ticker__dots" aria-hidden="true">
+      <span
+        v-for="(item, index) in items"
+        :key="item.id"
+        class="world-lobby-ticker__dot"
+        :class="{ 'world-lobby-ticker__dot--active': index === activeIndex }"
+      />
+    </div>
+  </button>
+</template>
+
+<style scoped>
+.world-lobby-ticker {
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  padding: 4px 2px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  box-shadow: none;
+  cursor: pointer;
+  transition: color 0.2s ease, opacity 0.2s ease;
+  text-align: left;
+}
+
+.world-lobby-ticker:hover .world-lobby-ticker__icon,
+.world-lobby-ticker:hover .world-lobby-ticker__title {
+  color: color-mix(in srgb, #3388de 78%, var(--sc-text-primary));
+}
+
+.world-lobby-ticker:focus-visible {
+  outline: 2px solid color-mix(in srgb, #3388de 28%, transparent);
+  outline-offset: 3px;
+}
+
+.world-lobby-ticker:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.world-lobby-ticker__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: color-mix(in srgb, #3388de 66%, var(--sc-text-secondary));
+  opacity: 0.9;
+}
+
+.world-lobby-ticker__content {
+  min-width: 0;
+}
+
+.world-lobby-ticker__line {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.world-lobby-ticker__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sc-text-primary);
+}
+
+.world-lobby-ticker__separator {
+  margin: 0 6px;
+  font-size: 12px;
+  color: color-mix(in srgb, var(--sc-text-secondary) 56%, transparent);
+}
+
+.world-lobby-ticker__summary {
+  font-size: 12px;
+  color: var(--sc-text-secondary);
+}
+
+.world-lobby-ticker__dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  justify-self: end;
+}
+
+.world-lobby-ticker__dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sc-text-secondary) 22%, transparent);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.world-lobby-ticker__dot--active {
+  background: color-mix(in srgb, #3388de 78%, var(--sc-text-primary));
+  transform: scale(1.1);
+}
+</style>

--- a/ui/src/components/audio/TrackMixerCard.vue
+++ b/ui/src/components/audio/TrackMixerCard.vue
@@ -37,14 +37,18 @@
     <section class="track-card__body">
       <div class="track-card__transport">
         <n-button
+          class="track-card__primary-action"
           size="tiny"
+          circle
           :type="isTrackPlaying ? 'warning' : 'primary'"
           :disabled="!track.assetId || isReadOnly"
+          :aria-label="isTrackPlaying ? '暂停' : '播放'"
           @click="togglePlay"
         >
-          {{ isTrackPlaying ? '暂停' : '播放' }}
+          <template #icon><n-icon :component="isTrackPlaying ? PlayerPause : PlayerPlay" /></template>
         </n-button>
         <n-button
+          class="track-card__mode-action"
           size="tiny"
           :type="track.loopEnabled ? 'info' : 'default'"
           quaternary
@@ -73,35 +77,43 @@
       </div>
 
       <div class="track-card__progress">
-        <n-slider
-          :value="progressPercent"
-          :step="0.5"
-          :disabled="!track.assetId || isReadOnly"
-          :format-tooltip="formatProgressTooltip"
-          @update:value="handleSeek"
-        />
-        <div class="track-card__progress-meta">
-          <span>{{ formatTime(currentSeconds) }}</span>
-          <span>{{ formatTime(track.duration) }}</span>
+        <span class="track-card__section-label">播放进度</span>
+        <div class="track-card__progress-row">
+          <span class="track-card__progress-time">{{ formatTime(currentSeconds) }}</span>
+          <n-slider
+            class="track-card__progress-slider track-card__progress-slider--primary"
+            :value="progressPercent"
+            :step="0.5"
+            :disabled="!track.assetId || isReadOnly"
+            :format-tooltip="formatProgressTooltip"
+            @update:value="handleSeek"
+          />
+          <span class="track-card__progress-time">{{ formatTime(track.duration) }}</span>
         </div>
       </div>
 
-      <div class="track-card__volume">
-        <span>音量</span>
+      <div class="track-card__control track-card__control--volume">
+        <span class="track-card__control-icon" aria-hidden="true">🔉</span>
+        <span class="track-card__section-label">音量</span>
         <n-slider
+          class="track-card__control-slider track-card__volume-slider"
           :value="track.volume"
           :step="0.01"
           @update:value="setVolume"
           :min="0"
           :max="1"
           :disabled="isReadOnly"
-        ></n-slider>
+        />
+        <span class="track-card__control-icon track-card__control-icon--right" aria-hidden="true">🔊</span>
+        <span class="track-card__control-value">{{ Math.round(track.volume * 100) }}%</span>
       </div>
 
       <div class="track-card__fade">
-        <div class="track-card__fade-item">
-          <span>淡入</span>
+        <div class="track-card__control track-card__control--fade">
+          <span class="track-card__control-icon" aria-hidden="true">↘</span>
+          <span class="track-card__section-label">淡入</span>
           <n-slider
+            class="track-card__control-slider track-card__fade-slider"
             :value="track.fadeIn"
             :step="100"
             :min="0"
@@ -110,11 +122,13 @@
             :disabled="isReadOnly"
             @update:value="setFadeIn"
           />
-          <span class="track-card__fade-value">{{ (track.fadeIn / 1000).toFixed(1) }}s</span>
+          <span class="track-card__control-value">{{ (track.fadeIn / 1000).toFixed(1) }}s</span>
         </div>
-        <div class="track-card__fade-item">
-          <span>淡出</span>
+        <div class="track-card__control track-card__control--fade">
+          <span class="track-card__control-icon" aria-hidden="true">↗</span>
+          <span class="track-card__section-label">淡出</span>
           <n-slider
+            class="track-card__control-slider track-card__fade-slider"
             :value="track.fadeOut"
             :step="100"
             :min="0"
@@ -123,7 +137,7 @@
             :disabled="isReadOnly"
             @update:value="setFadeOut"
           />
-          <span class="track-card__fade-value">{{ (track.fadeOut / 1000).toFixed(1) }}s</span>
+          <span class="track-card__control-value">{{ (track.fadeOut / 1000).toFixed(1) }}s</span>
         </div>
       </div>
 
@@ -174,6 +188,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { PropType } from 'vue';
+import { PlayerPause, PlayerPlay } from '@vicons/tabler';
 import type { TrackRuntime } from '@/stores/audioStudio';
 import type { AudioAsset, PlaylistMode } from '@/types/audio';
 import { useAudioStudioStore } from '@/stores/audioStudio';
@@ -330,6 +345,14 @@ function handleNext() {
 
 <style scoped lang="scss">
 .track-card {
+  --audio-control-rail: rgba(148, 163, 184, 0.2);
+  --audio-control-rail-hover: rgba(148, 163, 184, 0.28);
+  --audio-control-fill: rgba(148, 163, 184, 0.72);
+  --audio-control-fill-hover: rgba(203, 213, 225, 0.9);
+  --audio-control-handle: rgba(255, 255, 255, 0.96);
+  --audio-control-handle-border: rgba(148, 163, 184, 0.45);
+  --audio-progress-rail: rgba(51, 65, 85, 0.92);
+  --audio-progress-fill: linear-gradient(90deg, #34d399, #14b8a6);
   border: 1px solid var(--audio-card-border, var(--sc-border-mute));
   border-radius: 12px;
   padding: 1rem;
@@ -408,6 +431,14 @@ function handleNext() {
   flex-wrap: wrap;
 }
 
+.track-card__primary-action {
+  flex-shrink: 0;
+}
+
+.track-card__mode-action {
+  opacity: 0.92;
+}
+
 .track-card__speed {
   width: 96px;
   flex-shrink: 0;
@@ -416,50 +447,117 @@ function handleNext() {
 .track-card__progress {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.45rem;
 }
 
-.track-card__progress-meta {
-  display: flex;
-  justify-content: space-between;
+.track-card__progress-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.track-card__progress-time {
   font-size: 0.75rem;
+  color: var(--sc-text-secondary, #a0aec0);
+  font-variant-numeric: tabular-nums;
+}
+
+.track-card__progress-slider {
+  width: 100%;
+}
+
+.track-card__section-label {
+  font-size: 0.75rem;
+  color: var(--sc-text-secondary, #a0aec0);
+  white-space: nowrap;
+}
+
+.track-card__control {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
   color: var(--sc-text-secondary, #a0aec0);
 }
 
-.track-card__volume {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  color: var(--sc-text-secondary);
+.track-card__control-icon {
+  width: 1rem;
+  font-size: 0.88rem;
+  line-height: 1;
+  text-align: center;
+  color: rgba(148, 163, 184, 0.88);
+  flex-shrink: 0;
+}
+
+.track-card__control-icon--right {
+  color: rgba(203, 213, 225, 0.92);
+}
+
+.track-card__control-slider {
+  flex: 1;
+  min-width: 0;
+  --n-rail-height: 4px;
+  --n-rail-color: var(--audio-control-rail);
+  --n-rail-color-hover: var(--audio-control-rail-hover);
+  --n-fill-color: var(--audio-control-fill);
+  --n-fill-color-hover: var(--audio-control-fill-hover);
+  --n-handle-color: var(--audio-control-handle);
+  --n-handle-size: 12px;
+}
+
+.track-card__control-value {
+  width: 3rem;
+  flex-shrink: 0;
+  text-align: right;
+  font-size: 0.75rem;
+  color: rgba(203, 213, 225, 0.92);
+  font-variant-numeric: tabular-nums;
 }
 
 .track-card__fade {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.55rem;
 }
 
-.track-card__fade-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.75rem;
-  color: var(--sc-text-secondary);
+.track-card__progress-slider--primary {
+  --n-rail-height: 12px;
+  --n-rail-color: var(--audio-progress-rail);
+  --n-rail-color-hover: var(--audio-progress-rail);
+  --n-fill-color: var(--audio-progress-fill);
+  --n-fill-color-hover: var(--audio-progress-fill);
+  --n-handle-size: 12px;
 }
 
-.track-card__fade-item > span:first-child {
-  width: 2rem;
-  flex-shrink: 0;
+:deep(.track-card__progress-slider--primary .n-slider-rail) {
+  height: 12px;
+  border-radius: 999px;
 }
 
-.track-card__fade-item .n-slider {
-  flex: 1;
+:deep(.track-card__progress-slider--primary .n-slider-rail__fill) {
+  border-radius: 999px;
 }
 
-.track-card__fade-value {
-  width: 3rem;
-  text-align: right;
-  flex-shrink: 0;
+:deep(.track-card__progress-slider--primary .n-slider-handles) {
+  pointer-events: none;
+}
+
+:deep(.track-card__progress-slider--primary .n-slider-handle-wrapper) {
+  opacity: 0;
+}
+
+:deep(.track-card__progress-slider--primary .n-slider-handle) {
+  display: none;
+}
+
+:deep(.track-card__control-slider .n-slider-rail) {
+  height: 4px;
+}
+
+:deep(.track-card__control-slider .n-slider-handle) {
+  background-color: var(--audio-control-handle);
+  border: 1px solid var(--audio-control-handle-border);
+  box-sizing: border-box;
 }
 
 .track-card__footer {

--- a/ui/src/components/audio/TrackMixerCard.vue
+++ b/ui/src/components/audio/TrackMixerCard.vue
@@ -40,7 +40,7 @@
           class="track-card__primary-action"
           size="tiny"
           circle
-          :type="isTrackPlaying ? 'warning' : 'primary'"
+          :class="{ 'track-card__primary-action--active': isTrackPlaying }"
           :disabled="!track.assetId || isReadOnly"
           :aria-label="isTrackPlaying ? '暂停' : '播放'"
           @click="togglePlay"
@@ -192,6 +192,7 @@ import { PlayerPause, PlayerPlay } from '@vicons/tabler';
 import type { TrackRuntime } from '@/stores/audioStudio';
 import type { AudioAsset, PlaylistMode } from '@/types/audio';
 import { useAudioStudioStore } from '@/stores/audioStudio';
+import { isTrackPlaybackActive } from '@/stores/audioPlaybackState';
 
 const props = defineProps({
   track: {
@@ -223,7 +224,7 @@ const speedOptions = [
 
 const audio = useAudioStudioStore();
 const isReadOnly = computed(() => !audio.canManage);
-const isTrackPlaying = computed(() => props.track.status === 'playing');
+const isTrackPlaying = computed(() => isTrackPlaybackActive(props.track));
 const progressPercent = computed(() => Math.round(props.track.progress * 100));
 const currentSeconds = computed(() => {
   const duration = props.track.duration || 0;
@@ -433,6 +434,34 @@ function handleNext() {
 
 .track-card__primary-action {
   flex-shrink: 0;
+  --n-color: rgba(148, 163, 184, 0.12);
+  --n-color-hover: rgba(148, 163, 184, 0.18);
+  --n-color-pressed: rgba(148, 163, 184, 0.22);
+  --n-border: 1px solid rgba(148, 163, 184, 0.18);
+  --n-border-hover: 1px solid rgba(148, 163, 184, 0.26);
+  --n-border-pressed: 1px solid rgba(148, 163, 184, 0.32);
+  --n-text-color: rgba(226, 232, 240, 0.86);
+  --n-text-color-hover: rgba(248, 250, 252, 0.96);
+  --n-text-color-pressed: rgba(248, 250, 252, 0.96);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+}
+
+.track-card__primary-action:hover {
+  transform: translateY(-1px);
+}
+
+.track-card__primary-action--active {
+  --n-color: rgba(20, 184, 166, 0.12);
+  --n-color-hover: rgba(20, 184, 166, 0.18);
+  --n-color-pressed: rgba(20, 184, 166, 0.22);
+  --n-border: 1px solid rgba(45, 212, 191, 0.3);
+  --n-border-hover: 1px solid rgba(94, 234, 212, 0.4);
+  --n-border-pressed: 1px solid rgba(94, 234, 212, 0.44);
+  --n-text-color: #ccfbf1;
+  --n-text-color-hover: #f0fdfa;
+  --n-text-color-pressed: #f0fdfa;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0 0 1px rgba(45, 212, 191, 0.08), 0 0 16px rgba(20, 184, 166, 0.1);
 }
 
 .track-card__mode-action {

--- a/ui/src/components/audio/TransportBar.vue
+++ b/ui/src/components/audio/TransportBar.vue
@@ -1,30 +1,44 @@
 <template>
   <div class="transport-bar">
     <div class="transport-bar__controls">
-      <n-button type="primary" size="small" @click="togglePlay" :disabled="isReadOnly">
-        {{ audio.isPlaying ? '全部暂停' : '全部播放' }}
+      <n-button
+        class="transport-bar__primary-action"
+        type="primary"
+        size="small"
+        circle
+        @click="togglePlay"
+        :disabled="isReadOnly"
+        :aria-label="audio.isPlaying ? '全部暂停' : '全部播放'"
+      >
+        <template #icon><n-icon :component="audio.isPlaying ? PlayerPause : PlayerPlay" /></template>
       </n-button>
     </div>
 
     <div class="transport-bar__volume">
+      <span class="transport-bar__control-icon" aria-hidden="true">🔉</span>
       <span class="transport-bar__volume-label">总音量</span>
       <n-slider
+        class="transport-bar__volume-slider"
         :value="audio.masterVolume"
         :step="0.01"
         :min="0"
         :max="1"
         @update:value="handleVolumeChange"
       />
+      <span class="transport-bar__control-icon transport-bar__control-icon--right" aria-hidden="true">🔊</span>
+      <span class="transport-bar__volume-value">{{ masterVolumePercent }}%</span>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { PlayerPause, PlayerPlay } from '@vicons/tabler';
 import { useAudioStudioStore } from '@/stores/audioStudio';
 
 const audio = useAudioStudioStore();
 const isReadOnly = computed(() => !audio.canManage);
+const masterVolumePercent = computed(() => Math.round(audio.masterVolume * 100));
 
 function togglePlay() {
   audio.togglePlay();
@@ -37,6 +51,12 @@ function handleVolumeChange(volume: number) {
 
 <style scoped lang="scss">
 .transport-bar {
+  --audio-control-rail: rgba(148, 163, 184, 0.2);
+  --audio-control-rail-hover: rgba(148, 163, 184, 0.28);
+  --audio-control-fill: rgba(203, 213, 225, 0.72);
+  --audio-control-fill-hover: linear-gradient(90deg, #34d399, #14b8a6);
+  --audio-control-handle: rgba(255, 255, 255, 0.96);
+  --audio-control-handle-border: rgba(148, 163, 184, 0.45);
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -52,18 +72,65 @@ function handleVolumeChange(volume: number) {
   flex-shrink: 0;
 }
 
+.transport-bar__primary-action {
+  flex-shrink: 0;
+}
+
 .transport-bar__volume {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.55rem;
   flex: 1;
   min-width: 120px;
+}
+
+.transport-bar__control-icon {
+  width: 1rem;
+  text-align: center;
+  font-size: 0.88rem;
+  color: rgba(148, 163, 184, 0.88);
+  flex-shrink: 0;
+}
+
+.transport-bar__control-icon--right {
+  color: rgba(203, 213, 225, 0.92);
 }
 
 .transport-bar__volume-label {
   font-size: 0.75rem;
   color: var(--sc-text-secondary, #a0aec0);
   white-space: nowrap;
+}
+
+.transport-bar__volume-slider {
+  flex: 1;
+  min-width: 0;
+  --n-rail-height: 4px;
+  --n-rail-color: var(--audio-control-rail);
+  --n-rail-color-hover: var(--audio-control-rail-hover);
+  --n-fill-color: var(--audio-control-fill);
+  --n-fill-color-hover: var(--audio-control-fill-hover);
+  --n-handle-color: var(--audio-control-handle);
+  --n-handle-size: 12px;
+}
+
+.transport-bar__volume-value {
+  width: 2.75rem;
+  text-align: right;
+  font-size: 0.75rem;
+  color: rgba(203, 213, 225, 0.92);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+:deep(.transport-bar__volume-slider .n-slider-rail) {
+  height: 4px;
+}
+
+:deep(.transport-bar__volume-slider .n-slider-handle) {
+  background-color: var(--audio-control-handle);
+  border: 1px solid var(--audio-control-handle-border);
+  box-sizing: border-box;
 }
 </style>
 

--- a/ui/src/components/audio/TransportBar.vue
+++ b/ui/src/components/audio/TransportBar.vue
@@ -3,14 +3,14 @@
     <div class="transport-bar__controls">
       <n-button
         class="transport-bar__primary-action"
-        type="primary"
         size="small"
         circle
         @click="togglePlay"
         :disabled="isReadOnly"
-        :aria-label="audio.isPlaying ? '全部暂停' : '全部播放'"
+        :class="{ 'transport-bar__primary-action--active': isTransportPlaying }"
+        :aria-label="isTransportPlaying ? '全部暂停' : '全部播放'"
       >
-        <template #icon><n-icon :component="audio.isPlaying ? PlayerPause : PlayerPlay" /></template>
+        <template #icon><n-icon :component="isTransportPlaying ? PlayerPause : PlayerPlay" /></template>
       </n-button>
     </div>
 
@@ -35,10 +35,12 @@
 import { computed } from 'vue';
 import { PlayerPause, PlayerPlay } from '@vicons/tabler';
 import { useAudioStudioStore } from '@/stores/audioStudio';
+import { hasAnyActivePlayback } from '@/stores/audioPlaybackState';
 
 const audio = useAudioStudioStore();
 const isReadOnly = computed(() => !audio.canManage);
 const masterVolumePercent = computed(() => Math.round(audio.masterVolume * 100));
+const isTransportPlaying = computed(() => hasAnyActivePlayback(Object.values(audio.tracks || {})));
 
 function togglePlay() {
   audio.togglePlay();
@@ -74,6 +76,34 @@ function handleVolumeChange(volume: number) {
 
 .transport-bar__primary-action {
   flex-shrink: 0;
+  --n-color: rgba(148, 163, 184, 0.12);
+  --n-color-hover: rgba(148, 163, 184, 0.18);
+  --n-color-pressed: rgba(148, 163, 184, 0.22);
+  --n-border: 1px solid rgba(148, 163, 184, 0.18);
+  --n-border-hover: 1px solid rgba(148, 163, 184, 0.28);
+  --n-border-pressed: 1px solid rgba(148, 163, 184, 0.32);
+  --n-text-color: rgba(226, 232, 240, 0.88);
+  --n-text-color-hover: rgba(248, 250, 252, 0.96);
+  --n-text-color-pressed: rgba(248, 250, 252, 0.96);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+}
+
+.transport-bar__primary-action:hover {
+  transform: translateY(-1px);
+}
+
+.transport-bar__primary-action--active {
+  --n-color: rgba(20, 184, 166, 0.14);
+  --n-color-hover: rgba(20, 184, 166, 0.2);
+  --n-color-pressed: rgba(20, 184, 166, 0.24);
+  --n-border: 1px solid rgba(45, 212, 191, 0.32);
+  --n-border-hover: 1px solid rgba(94, 234, 212, 0.42);
+  --n-border-pressed: 1px solid rgba(94, 234, 212, 0.46);
+  --n-text-color: #ccfbf1;
+  --n-text-color-hover: #f0fdfa;
+  --n-text-color-pressed: #f0fdfa;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0 0 1px rgba(45, 212, 191, 0.08), 0 0 18px rgba(20, 184, 166, 0.12);
 }
 
 .transport-bar__volume {

--- a/ui/src/models/announcement.ts
+++ b/ui/src/models/announcement.ts
@@ -18,6 +18,7 @@ export interface AnnouncementItem {
   status: AnnouncementStatus
   isPinned: boolean
   pinOrder: number
+  showInTicker: boolean
   popupMode: AnnouncementPopupMode
   reminderScope: AnnouncementReminderScope
   requireAck: boolean
@@ -49,6 +50,7 @@ export interface AnnouncementPayload {
   status: AnnouncementStatus
   isPinned: boolean
   pinOrder: number
+  showInTicker: boolean
   popupMode: AnnouncementPopupMode
   reminderScope: AnnouncementReminderScope
   requireAck: boolean
@@ -88,7 +90,7 @@ export async function ackWorldAnnouncement(worldId: string, announcementId: stri
   return data.item
 }
 
-export async function fetchLobbyAnnouncements(params?: { page?: number; pageSize?: number; includeAll?: boolean; includeArchived?: boolean }) {
+export async function fetchLobbyAnnouncements(params?: { page?: number; pageSize?: number; includeAll?: boolean; includeArchived?: boolean; showInTicker?: boolean }) {
   const { data } = await api.get<AnnouncementListResponse>('/api/v1/lobby-announcements', { params })
   return data
 }

--- a/ui/src/stores/announcement.ts
+++ b/ui/src/stores/announcement.ts
@@ -21,7 +21,7 @@ export const useAnnouncementStore = defineStore('announcement', () => {
     return fetchWorldAnnouncements(worldId, params)
   }
 
-  async function fetchLobbyList(params?: { page?: number; pageSize?: number; includeAll?: boolean; includeArchived?: boolean }) {
+  async function fetchLobbyList(params?: { page?: number; pageSize?: number; includeAll?: boolean; includeArchived?: boolean; showInTicker?: boolean }) {
     return fetchLobbyAnnouncements(params)
   }
 

--- a/ui/src/stores/audioPlaybackState.ts
+++ b/ui/src/stores/audioPlaybackState.ts
@@ -1,0 +1,45 @@
+type PlaybackStatus = 'idle' | 'loading' | 'ready' | 'playing' | 'paused' | 'error';
+
+type PlayableHowl = {
+  playing?: () => boolean;
+} | null | undefined;
+
+type PlayableTrack = {
+  status?: PlaybackStatus;
+  howl?: PlayableHowl;
+} | null | undefined;
+
+function safeHowlPlaying(howl?: PlayableHowl) {
+  if (!howl || typeof howl.playing !== 'function') {
+    return false;
+  }
+  try {
+    return Boolean(howl.playing());
+  } catch {
+    return false;
+  }
+}
+
+export function isTrackPlaybackActive(track?: PlayableTrack) {
+  if (!track) {
+    return false;
+  }
+  return safeHowlPlaying(track.howl) || track.status === 'playing';
+}
+
+export function hasAnyActivePlayback(tracks: Array<PlayableTrack>) {
+  return tracks.some((track) => isTrackPlaybackActive(track));
+}
+
+export function normalizeTrackStatus(track?: PlayableTrack): PlaybackStatus {
+  if (!track) {
+    return 'idle';
+  }
+  if (safeHowlPlaying(track.howl)) {
+    return 'playing';
+  }
+  if (track.status === 'playing') {
+    return 'playing';
+  }
+  return track.status || 'idle';
+}

--- a/ui/src/stores/audioStudio.ts
+++ b/ui/src/stores/audioStudio.ts
@@ -7,6 +7,7 @@ import { useUtilsStore } from './utils';
 import { chatEvent, useChatStore } from './chat';
 import { audioDb, toCachedMeta } from '@/models/audio-cache';
 import { ensurePinyinLoaded, matchText } from '@/utils/pinyinMatch';
+import { hasAnyActivePlayback, isTrackPlaybackActive, normalizeTrackStatus } from './audioPlaybackState';
 import type {
   AudioAsset,
   AudioAssetMutationPayload,
@@ -1315,11 +1316,7 @@ export const useAudioStudioStore = defineStore('audioStudio', {
     buildTrackStatePayload(): AudioTrackStatePayload[] {
       return DEFAULT_TRACK_TYPES.map((type) => {
         const track = this.tracks[type] || createEmptyTrack(type);
-        const trackIsPlaying = Boolean(
-          track.assetId &&
-            !track.muted &&
-            (track.status === 'playing' || (this.isPlaying && track.status !== 'paused')),
-        );
+        const trackIsPlaying = Boolean(track.assetId && !track.muted && isTrackPlaybackActive(track));
         const trackPosition = track.howl ? (track.howl.seek() as number) : 0;
         return {
           type,
@@ -1947,7 +1944,7 @@ export const useAudioStudioStore = defineStore('audioStudio', {
         volume: track.volume,
         onplay: () => {
           track.status = 'playing';
-          // 仅启动进度监控，不更新全局 isPlaying（由 playAll/playTrack 显式控制）
+          this.isPlaying = true;
           if (!this.isApplyingRemoteState) {
             startProgressWatcher(this);
           }
@@ -1955,9 +1952,11 @@ export const useAudioStudioStore = defineStore('audioStudio', {
         },
         onpause: () => {
           track.status = 'paused';
+          this.refreshPlaybackFlags();
         },
         onstop: () => {
           track.status = 'ready';
+          this.refreshPlaybackFlags();
         },
         onend: () => {
           track.status = 'ready';
@@ -1967,6 +1966,7 @@ export const useAudioStudioStore = defineStore('audioStudio', {
             return;
           }
           // 仅当所有轨道都空闲时停止进度监控
+          this.refreshPlaybackFlags();
           if (!this.isApplyingRemoteState && this.allTracksIdle()) {
             stopProgressWatcher();
           }
@@ -1984,12 +1984,14 @@ export const useAudioStudioStore = defineStore('audioStudio', {
         onloaderror: (_, err) => {
           track.status = 'error';
           track.error = String(err);
+          this.refreshPlaybackFlags();
         },
         onplayerror: (_, err) => {
           // 自动播放被阻止时，设置为暂停状态而非错误状态
           // 用户可以通过点击播放按钮手动触发
           console.warn('Play error (likely autoplay blocked):', err);
           track.status = 'paused';
+          this.refreshPlaybackFlags();
           if (!this.canManage && this.remoteState?.isPlaying) {
             this.pendingRemotePlay = true;
           }
@@ -2013,6 +2015,7 @@ export const useAudioStudioStore = defineStore('audioStudio', {
           // 使用轨道级别的循环和倍速设置
           track.howl.loop(track.loopEnabled ?? true);
           track.howl.rate(track.playbackRate ?? 1);
+          track.status = 'playing';
           // 防止重复播放
           if (!track.howl.playing()) {
             track.howl.play();
@@ -2034,6 +2037,9 @@ export const useAudioStudioStore = defineStore('audioStudio', {
         if (track?.howl && track.howl.playing()) {
           track.howl.pause();
         }
+        if (track?.assetId && isTrackPlaybackActive(track)) {
+          track.status = 'paused';
+        }
       });
       this.isPlaying = false;
       stopProgressWatcher();
@@ -2044,6 +2050,7 @@ export const useAudioStudioStore = defineStore('audioStudio', {
 
     togglePlay() {
       if (!this.canManage) return;
+      this.refreshPlaybackFlags();
       if (this.isPlaying) {
         this.pauseAll();
       } else {
@@ -2103,10 +2110,12 @@ export const useAudioStudioStore = defineStore('audioStudio', {
       const track = this.tracks[type];
       if (!track?.howl || !track.assetId) return;
       // 防止重复播放：如果已经在播放，直接返回
-      if (track.howl.playing()) return;
+      if (isTrackPlaybackActive(track)) return;
       // 使用轨道级别的循环和倍速设置
       track.howl.loop(track.loopEnabled ?? true);
       track.howl.rate(track.playbackRate ?? 1);
+      track.status = 'playing';
+      this.isPlaying = true;
       track.howl.play();
       // 启动进度监控（如果未启动）
       startProgressWatcher(this);
@@ -2121,6 +2130,8 @@ export const useAudioStudioStore = defineStore('audioStudio', {
       if (track.howl.playing()) {
         track.howl.pause();
       }
+      track.status = 'paused';
+      this.refreshPlaybackFlags();
       // 仅当所有轨道都空闲时才停止进度监控
       if (this.allTracksIdle()) {
         stopProgressWatcher();
@@ -2133,7 +2144,7 @@ export const useAudioStudioStore = defineStore('audioStudio', {
     toggleTrackPlay(type: AudioTrackType) {
       const track = this.tracks[type];
       if (!track?.howl) return;
-      if (track.howl.playing()) {
+      if (isTrackPlaybackActive(track)) {
         this.pauseTrack(type);
       } else {
         this.playTrack(type);
@@ -2200,6 +2211,7 @@ export const useAudioStudioStore = defineStore('audioStudio', {
         track.howl.unload();
       }
       this.tracks[type] = createEmptyTrack(type);
+      this.refreshPlaybackFlags();
       if (this.allTracksIdle()) {
         this.isPlaying = false;
         stopProgressWatcher();
@@ -2301,15 +2313,22 @@ export const useAudioStudioStore = defineStore('audioStudio', {
     allTracksIdle() {
       return DEFAULT_TRACK_TYPES.every((type) => {
         const track = this.tracks[type];
-        return !track || track.status === 'idle' || track.status === 'ready' || track.status === 'paused';
+        const status = normalizeTrackStatus(track);
+        return !track || status === 'idle' || status === 'ready' || status === 'paused';
       });
     },
 
     anyTrackPlaying() {
-      return DEFAULT_TRACK_TYPES.some((type) => {
+      return hasAnyActivePlayback(DEFAULT_TRACK_TYPES.map((type) => this.tracks[type]));
+    },
+
+    refreshPlaybackFlags() {
+      DEFAULT_TRACK_TYPES.forEach((type) => {
         const track = this.tracks[type];
-        return track?.howl?.playing();
+        if (!track) return;
+        track.status = normalizeTrackStatus(track);
       });
+      this.isPlaying = this.anyTrackPlaying();
     },
 
     async applyFilters(filters: Partial<AudioSearchFilters>) {

--- a/ui/src/stores/characterCardTemplate.ts
+++ b/ui/src/stores/characterCardTemplate.ts
@@ -13,6 +13,12 @@ export interface CharacterCardTemplate {
   content: string;
   isGlobalDefault: boolean;
   isSheetDefault: boolean;
+  access?: 'owner' | 'world_shared';
+  readonly?: boolean;
+  isSharedToCurrentWorld?: boolean;
+  sharedWorldId?: string;
+  sharedByUserId?: string;
+  sharedByNickname?: string;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -37,6 +43,11 @@ interface TemplatePayload {
   content: string;
   isGlobalDefault?: boolean;
   isSheetDefault?: boolean;
+}
+
+interface TemplateQueryOptions {
+  sheetType?: string;
+  worldId?: string;
 }
 
 interface BindingPayload {
@@ -82,6 +93,7 @@ export const useCharacterCardTemplateStore = defineStore('characterCardTemplate'
   const templatesLoaded = ref(false);
   const loading = ref(false);
   const migrating = ref(false);
+  const loadedWorldId = ref('');
 
   const templates = computed(() => Object.values(templateMap.value));
 
@@ -106,11 +118,11 @@ export const useCharacterCardTemplateStore = defineStore('characterCardTemplate'
   const getSheetDefaultTemplate = (sheetType?: string) => {
     const normalized = normalizeSheetType(sheetType);
     if (!normalized) return null;
-    return templates.value.find(item => item.isSheetDefault && normalizeSheetType(item.sheetType) === normalized) || null;
+    return templates.value.find(item => !item.readonly && item.isSheetDefault && normalizeSheetType(item.sheetType) === normalized) || null;
   };
 
   const getGlobalDefaultTemplate = () => {
-    return templates.value.find(item => item.isGlobalDefault) || null;
+    return templates.value.find(item => item.isGlobalDefault && !item.readonly) || null;
   };
 
   const resolveDefaultTemplate = (sheetType?: string, fallback = '') => {
@@ -138,11 +150,16 @@ export const useCharacterCardTemplateStore = defineStore('characterCardTemplate'
     return resolveDefaultTemplate(sheetType, fallback);
   };
 
-  const loadTemplates = async (sheetType?: string) => {
+  const loadTemplates = async (options?: TemplateQueryOptions) => {
     loading.value = true;
     try {
+      const sheetType = options?.sheetType;
+      const worldId = String(options?.worldId ?? loadedWorldId.value ?? '').trim();
       const resp = await api.get('/api/v1/character-card-templates', {
-        params: sheetType ? { sheetType } : {},
+        params: {
+          ...(sheetType ? { sheetType } : {}),
+          ...(worldId ? { worldId } : {}),
+        },
       });
       const items = Array.isArray(resp.data?.items) ? resp.data.items as CharacterCardTemplate[] : [];
       const nextMap: Record<string, CharacterCardTemplate> = {};
@@ -153,15 +170,17 @@ export const useCharacterCardTemplateStore = defineStore('characterCardTemplate'
       });
       templateMap.value = nextMap;
       templatesLoaded.value = true;
+      loadedWorldId.value = worldId;
       return items;
     } finally {
       loading.value = false;
     }
   };
 
-  const ensureTemplatesLoaded = async () => {
-    if (templatesLoaded.value) return;
-    await loadTemplates();
+  const ensureTemplatesLoaded = async (options?: TemplateQueryOptions) => {
+    const worldId = String(options?.worldId ?? loadedWorldId.value ?? '').trim();
+    if (templatesLoaded.value && loadedWorldId.value === worldId) return;
+    await loadTemplates({ ...options, worldId: worldId || undefined });
   };
 
   const createTemplate = async (payload: TemplatePayload) => {
@@ -201,6 +220,16 @@ export const useCharacterCardTemplateStore = defineStore('characterCardTemplate'
     const item = resp.data?.item as CharacterCardTemplate | undefined;
     await loadTemplates();
     return item || null;
+  };
+
+  const shareTemplateToWorld = async (worldId: string, templateId: string) => {
+    await api.post(`/api/v1/worlds/${worldId}/character-card-templates/${templateId}/share`);
+    await loadTemplates({ worldId });
+  };
+
+  const unshareTemplateFromWorld = async (worldId: string, templateId: string) => {
+    await api.delete(`/api/v1/worlds/${worldId}/character-card-templates/${templateId}/share`);
+    await loadTemplates({ worldId });
   };
 
   const loadBindings = async (channelId: string) => {
@@ -442,6 +471,8 @@ export const useCharacterCardTemplateStore = defineStore('characterCardTemplate'
     updateTemplate,
     deleteTemplate,
     setTemplateDefault,
+    shareTemplateToWorld,
+    unshareTemplateFromWorld,
     loadBindings,
     ensureBindingsLoaded,
     upsertBinding,

--- a/ui/src/stores/characterRemark.ts
+++ b/ui/src/stores/characterRemark.ts
@@ -9,7 +9,7 @@ export interface CharacterRemarkEntry {
   channelId: string
   userId: string
   content: string
-  updatedAt: number
+  revision: number
 }
 
 const CHARACTER_REMARK_MAX_LENGTH = 80
@@ -85,20 +85,23 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
     let changed = false
     Object.values(cached).forEach((entry) => {
       if (!entry || typeof entry !== 'object') return
-      const identityId = typeof entry.identityId === 'string' ? entry.identityId : ''
+      const rawEntry = entry as CharacterRemarkEntry & { updatedAt?: number }
+      const identityId = typeof rawEntry.identityId === 'string' ? rawEntry.identityId : ''
       if (!identityId) return
       const normalized: CharacterRemarkEntry = {
         identityId,
-        channelId: typeof entry.channelId === 'string' && entry.channelId ? entry.channelId : channelId,
-        userId: typeof entry.userId === 'string' ? entry.userId : '',
-        content: typeof entry.content === 'string' ? entry.content : '',
-        updatedAt: typeof entry.updatedAt === 'number' ? entry.updatedAt : 0,
+        channelId: typeof rawEntry.channelId === 'string' && rawEntry.channelId ? rawEntry.channelId : channelId,
+        userId: typeof rawEntry.userId === 'string' ? rawEntry.userId : '',
+        content: typeof rawEntry.content === 'string' ? rawEntry.content : '',
+        revision: typeof rawEntry.revision === 'number'
+          ? rawEntry.revision
+          : (typeof rawEntry.updatedAt === 'number' ? rawEntry.updatedAt : 0),
       }
       if (!normalized.content.trim()) {
         return
       }
       const existing = next[identityId]
-      if (!existing || normalized.updatedAt > existing.updatedAt) {
+      if (!existing || normalized.revision > existing.revision) {
         next[identityId] = normalized
         changed = true
       }
@@ -110,7 +113,7 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
 
   const upsertRemarkEntry = (entry: CharacterRemarkEntry) => {
     const existing = remarkByIdentity.value[entry.identityId]
-    if (existing && entry.updatedAt <= existing.updatedAt) {
+    if (existing && entry.revision <= existing.revision) {
       return
     }
     remarkByIdentity.value = { ...remarkByIdentity.value, [entry.identityId]: entry }
@@ -129,7 +132,7 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
     if (!key) return
     const channelMap = { ...(remarkCacheByChannel.value[entry.channelId] || {}) }
     const existing = channelMap[entry.identityId]
-    if (existing && entry.updatedAt <= existing.updatedAt) {
+    if (existing && entry.revision <= existing.revision) {
       return
     }
     channelMap[entry.identityId] = entry
@@ -161,6 +164,33 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
     persistCache()
   }
 
+  const removeRemarkEntriesByChannel = (channelId: string) => {
+    if (!channelId) return
+    const next = { ...remarkByIdentity.value }
+    let changed = false
+    Object.keys(next).forEach((identityId) => {
+      if (next[identityId]?.channelId === channelId) {
+        delete next[identityId]
+        changed = true
+      }
+    })
+    if (changed) {
+      remarkByIdentity.value = next
+    }
+  }
+
+  const clearRemarkCacheForChannel = (channelId: string) => {
+    if (!channelId) return
+    const key = ensureCacheLoaded()
+    if (!key) return
+    if (!Object.prototype.hasOwnProperty.call(remarkCacheByChannel.value, channelId)) {
+      return
+    }
+    const { [channelId]: _removed, ...rest } = remarkCacheByChannel.value
+    remarkCacheByChannel.value = rest
+    persistCache()
+  }
+
   const replaceRemarkCacheForChannel = (channelId: string, entries: Record<string, CharacterRemarkEntry>) => {
     if (!channelId) return
     const key = ensureCacheLoaded()
@@ -178,8 +208,15 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
     if (!identityId) {
       return
     }
+    const revision = typeof payload?.revision === 'number'
+      ? payload.revision
+      : (typeof event?.timestamp === 'number' ? event.timestamp : Date.now())
     const action = typeof payload?.action === 'string' ? payload.action : 'update'
     if (action === 'clear') {
+      const existing = remarkByIdentity.value[identityId]
+      if (existing && revision < existing.revision) {
+        return
+      }
       const channelId = typeof event?.channel?.id === 'string'
         ? event.channel.id
         : remarkByIdentity.value[identityId]?.channelId || ''
@@ -199,7 +236,7 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
       channelId,
       userId: typeof payload?.userId === 'string' ? payload.userId : '',
       content,
-      updatedAt: typeof event?.timestamp === 'number' ? event.timestamp : Math.floor(Date.now() / 1000),
+      revision,
     }
     upsertRemarkEntry(entry)
     upsertRemarkCacheEntry(entry)
@@ -214,10 +251,10 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
       ? event.characterRemarkSnapshot.items
       : []
     if (!items.length) {
-      loadRemarkCache(channelId)
+      removeRemarkEntriesByChannel(channelId)
+      clearRemarkCacheForChannel(channelId)
       return
     }
-    const updatedAt = typeof event?.timestamp === 'number' ? event.timestamp : Math.floor(Date.now() / 1000)
     const next = { ...remarkByIdentity.value }
     const cacheNext: Record<string, CharacterRemarkEntry> = {}
     Object.keys(next).forEach((key) => {
@@ -236,7 +273,9 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
         channelId,
         userId: typeof item?.userId === 'string' ? item.userId : '',
         content,
-        updatedAt,
+        revision: typeof item?.revision === 'number'
+          ? item.revision
+          : (typeof event?.timestamp === 'number' ? event.timestamp : Date.now()),
       }
       next[identityId] = entry
       cacheNext[identityId] = entry
@@ -290,7 +329,7 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
     loadRemarkCache(channelId)
     await chatStore.ensureConnectionReady()
     try {
-      await chatStore.sendAPI('character.remark.snapshot', { channel_id: channelId })
+      await chatStore.sendAPI('character.remark.snapshot', { channel_id: channelId } as any)
     } catch (error) {
       console.warn('Failed to request character remark snapshot', error)
     }
@@ -312,14 +351,14 @@ export const useCharacterRemarkStore = defineStore('characterRemark', () => {
           channel_id: channelId,
           identity_id: identityId,
           action: 'clear',
-        })
+        } as any)
       } else {
         await chatStore.sendAPI('character.remark.broadcast', {
           channel_id: channelId,
           identity_id: identityId,
           content: normalized,
           action: 'update',
-        })
+        } as any)
       }
       return { ok: true as const }
     } catch (error: any) {

--- a/ui/src/stores/chat.ts
+++ b/ui/src/stores/chat.ts
@@ -19,6 +19,7 @@ import { useDisplayStore } from './display';
 import { normalizeAttachmentId } from '@/composables/useAttachmentResolver';
 import { getCategoriesKey as getBgCategoriesKey, getStorageKey as getBgStorageKey } from '@/utils/backgroundPreset';
 import { resolveNextUnreadCountForMessageNotice } from './chatUnreadNotice';
+import { findChannelByIdFromTree, findFirstEnterableChannel } from './chatChannelSelection';
 
 const inFlightChannelIdentityLoads = new Map<string, Promise<ChannelIdentity[]>>();
 const inFlightChannelIdentityVariantLoads = new Map<string, Promise<Record<string, ChannelIdentityVariant[]>>>();
@@ -76,6 +77,7 @@ const enqueueBotApi = async <T>(fn: () => Promise<T>): Promise<T> => {
     notifyBotIdle();
   }
 };
+
 const enqueueNormalApi = async <T>(fn: () => Promise<T>): Promise<T> => {
   await waitForBotIdle();
   normalApiInFlight += 1;
@@ -1267,7 +1269,7 @@ export const useChatStore = defineStore({
           targetChannel = readObserverSessionChannel(this.observerSlug, worldId);
         }
         const world = this.worldMap[worldId];
-        const fallbackChannel = world?.defaultChannelId || this.channelTreeByWorld[worldId]?.[0]?.id || this.channelTree[0]?.id || '';
+        const fallbackChannel = world?.defaultChannelId || findFirstEnterableChannel(this.channelTreeByWorld[worldId] || [])?.id || '';
         if (!targetChannel) {
           targetChannel = fallbackChannel;
         }
@@ -2124,9 +2126,16 @@ export const useChatStore = defineStore({
         this.setCurrentWorld(worldId);
         await this.channelList(worldId, options?.force ?? true);
       }
-      const firstChannel = this.channelTree[0];
-      if (firstChannel) {
-        await this.channelSwitchTo(firstChannel.id);
+      const currentChannelId = this.curChannel?.id ? String(this.curChannel.id).trim() : '';
+      if (currentChannelId && !findChannelByIdFromTree(this.channelTree, currentChannelId)) {
+        this.clearCurrentChannelContext('switchWorld:currentChannelNotInTargetTree');
+      }
+      const world = this.worldMap[worldId];
+      const fallbackChannelId = String(
+        world?.defaultChannelId || findFirstEnterableChannel(this.channelTree)?.id || '',
+      ).trim();
+      if (fallbackChannelId) {
+        await this.channelSwitchTo(fallbackChannelId);
       }
     },
 
@@ -2196,13 +2205,12 @@ export const useChatStore = defineStore({
         ts: Date.now(),
       });
 
-      let nextChannel = this.channelTree.find(c => c.id === id) ||
-        this.channelTree.flatMap(c => c.children || []).find(c => c.id === id);
+      let nextChannel: SChannel | null = findChannelByIdFromTree(this.channelTree, id);
 
       let isFromArchive = false;
 
       if (!nextChannel) {
-        nextChannel = this.channelTreePrivate.find(c => c.id === id);
+        nextChannel = this.channelTreePrivate.find(c => c.id === id) || null;
       }
 
       // 如果本地找不到（可能是归档频道），尝试从 API 获取
@@ -3224,19 +3232,7 @@ export const useChatStore = defineStore({
     },
 
     findChannelById(channelId: string): SChannel | null {
-      const traverse = (nodes: SChannel[] = []): SChannel | null => {
-        for (const node of nodes) {
-          if (node.id === channelId) {
-            return node;
-          }
-          const found = traverse(((node as any).children || []) as SChannel[]);
-          if (found) {
-            return found;
-          }
-        }
-        return null;
-      };
-      return traverse(this.channelTree) || this.channelTreePrivate.find(item => item.id === channelId) || null;
+      return findChannelByIdFromTree(this.channelTree, channelId) || this.channelTreePrivate.find(item => item.id === channelId) || null;
     },
 
     getChannelOwnerId(channelId?: string) {
@@ -3598,20 +3594,29 @@ export const useChatStore = defineStore({
       const resp = await this.sendAPI('channel.list', { world_id: finalWorld, worldId: finalWorld }) as APIChannelListResp;
       const d = resp.data;
       const chns = d.data ?? [];
-
-      const curItem = chns.find(c => c.id === this.curChannel?.id);
-      this.curChannel = curItem || this.curChannel;
-
       const tree = this.applyChannelTree(finalWorld, chns);
+      const currentChannelId = this.curChannel?.id ? String(this.curChannel.id).trim() : '';
+      const curItem = currentChannelId ? findChannelByIdFromTree(tree as SChannel[], currentChannelId) : null;
+      const preserveDetachedChannel = currentChannelId
+        && (
+          this.temporaryArchivedChannel?.id === currentChannelId
+          || (this.curChannel as any)?.isPrivate === true
+        );
+      if (curItem) {
+        this.curChannel = curItem;
+      } else if (currentChannelId && !preserveDetachedChannel) {
+        this.clearCurrentChannelContext('channelList:currentChannelMissingInTree');
+      }
 
       if (!this.curChannel) {
         // 这是为了正确标记人数，有点屎但实现了
         const lastChannel = this._lastChannel;
-        const c = this.channelTree.find(c => c.id === lastChannel);
+        const c = findChannelByIdFromTree(tree as SChannel[], lastChannel);
         if (c) {
           this.channelSwitchTo(c.id);
         } else {
-          if (tree[0]) this.channelSwitchTo(tree[0].id);
+          const firstChannel = findFirstEnterableChannel(tree as SChannel[]);
+          if (firstChannel) this.channelSwitchTo(firstChannel.id);
         }
       }
 
@@ -4955,9 +4960,19 @@ export const useChatStore = defineStore({
         this.curChannel = null;
       }
       await this.channelList(this.currentWorldId, true);
-      if (wasCurrent && this.channelTree.length) {
-        await this.channelSwitchTo(this.channelTree[0].id);
+      const fallbackChannelId = findFirstEnterableChannel(this.channelTree)?.id || '';
+      if (wasCurrent && fallbackChannelId) {
+        await this.channelSwitchTo(fallbackChannelId);
       }
+    },
+
+    clearCurrentChannelContext(reason = '') {
+      this.curChannel = null;
+      this.curMember = null;
+      this.curChannelUsers = [];
+      this.whisperTargets = [];
+      this.firstUnreadInfo = null;
+      this.temporaryArchivedChannel = null;
     },
 
     // 频道归档

--- a/ui/src/stores/chatChannelSelection.ts
+++ b/ui/src/stores/chatChannelSelection.ts
@@ -1,0 +1,47 @@
+import type { SChannel } from '../types';
+
+type ChannelLike = Pick<Partial<SChannel>, 'id' | 'type' | 'isPrivate'> & {
+  children?: ChannelLike[];
+};
+
+export const isEnterableChannel = (channel?: ChannelLike | null) => {
+  if (!channel?.id) {
+    return false;
+  }
+  return channel.type === 3 || channel.isPrivate === true;
+};
+
+export const findChannelByIdFromTree = <T extends ChannelLike>(nodes: T[] = [], channelId: string): T | null => {
+  if (!channelId) {
+    return null;
+  }
+  for (const node of nodes) {
+    if (!node) {
+      continue;
+    }
+    if (node.id === channelId) {
+      return node;
+    }
+    const found = findChannelByIdFromTree((node.children || []) as T[], channelId);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+};
+
+export const findFirstEnterableChannel = <T extends ChannelLike>(nodes: T[] = []): T | null => {
+  for (const node of nodes) {
+    if (!node) {
+      continue;
+    }
+    if (isEnterableChannel(node)) {
+      return node;
+    }
+    const found = findFirstEnterableChannel((node.children || []) as T[]);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+};

--- a/ui/src/stores/display.ts
+++ b/ui/src/stores/display.ts
@@ -3,6 +3,7 @@ import { useChatStore } from './chat'
 import { DEFAULT_MONO_FONT_STACK, buildGlobalFontFamilyStack, sanitizeFontFamilyName } from '@/services/font/fontUtils'
 import type { FontSourceType } from '@/services/font/types'
 import { restoreCachedFontById } from '@/services/font/fontLoader'
+import { DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION } from '@/utils/worldKeywordTooltipInteraction'
 
 export type DisplayLayout = 'bubble' | 'compact'
 export type DisplayPalette = 'day' | 'night'
@@ -110,6 +111,8 @@ export interface DisplaySettings {
   worldKeywordHighlightEnabled: boolean
   worldKeywordUnderlineOnly: boolean
   worldKeywordTooltipEnabled: boolean
+  worldKeywordTooltipHoverEnabled: boolean
+  worldKeywordTooltipClickEnabled: boolean
   worldKeywordDeduplicateEnabled: boolean
   worldKeywordTooltipTextIndent: number  // 术语气泡多段首行缩进（em），0 为关闭
   worldKeywordQuickInputEnabled: boolean  // 术语快捷输入
@@ -466,7 +469,9 @@ export const createDefaultDisplaySettings = (): DisplaySettings => ({
   favoriteChannelHotkeysByWorld: {},
   worldKeywordHighlightEnabled: true,
   worldKeywordUnderlineOnly: true,
-  worldKeywordTooltipEnabled: true,
+  worldKeywordTooltipEnabled: DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.tooltipEnabled,
+  worldKeywordTooltipHoverEnabled: DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.hoverEnabled,
+  worldKeywordTooltipClickEnabled: DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.clickEnabled,
   worldKeywordDeduplicateEnabled: true,
   worldKeywordTooltipTextIndent: KEYWORD_TOOLTIP_TEXT_INDENT_DEFAULT,
   worldKeywordQuickInputEnabled: true,
@@ -683,7 +688,15 @@ const loadSettings = (): DisplaySettings => {
       favoriteChannelHotkeysByWorld,
       worldKeywordHighlightEnabled: coerceBoolean((parsed as any)?.worldKeywordHighlightEnabled ?? true),
       worldKeywordUnderlineOnly: coerceBoolean((parsed as any)?.worldKeywordUnderlineOnly ?? true),
-      worldKeywordTooltipEnabled: coerceBoolean((parsed as any)?.worldKeywordTooltipEnabled ?? true),
+      worldKeywordTooltipEnabled: coerceBoolean(
+        (parsed as any)?.worldKeywordTooltipEnabled ?? DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.tooltipEnabled,
+      ),
+      worldKeywordTooltipHoverEnabled: coerceBoolean(
+        (parsed as any)?.worldKeywordTooltipHoverEnabled ?? DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.hoverEnabled,
+      ),
+      worldKeywordTooltipClickEnabled: coerceBoolean(
+        (parsed as any)?.worldKeywordTooltipClickEnabled ?? DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.clickEnabled,
+      ),
       worldKeywordDeduplicateEnabled: coerceBoolean((parsed as any)?.worldKeywordDeduplicateEnabled ?? true),
       worldKeywordTooltipTextIndent: coerceFloatInRange(
         (parsed as any)?.worldKeywordTooltipTextIndent,
@@ -890,6 +903,14 @@ const normalizeWith = (base: DisplaySettings, patch?: Partial<DisplaySettings>):
     patch && Object.prototype.hasOwnProperty.call(patch, 'worldKeywordTooltipEnabled')
       ? coerceBoolean((patch as any).worldKeywordTooltipEnabled)
       : base.worldKeywordTooltipEnabled,
+  worldKeywordTooltipHoverEnabled:
+    patch && Object.prototype.hasOwnProperty.call(patch, 'worldKeywordTooltipHoverEnabled')
+      ? coerceBoolean((patch as any).worldKeywordTooltipHoverEnabled)
+      : base.worldKeywordTooltipHoverEnabled,
+  worldKeywordTooltipClickEnabled:
+    patch && Object.prototype.hasOwnProperty.call(patch, 'worldKeywordTooltipClickEnabled')
+      ? coerceBoolean((patch as any).worldKeywordTooltipClickEnabled)
+      : base.worldKeywordTooltipClickEnabled,
   worldKeywordDeduplicateEnabled:
     patch && Object.prototype.hasOwnProperty.call(patch, 'worldKeywordDeduplicateEnabled')
       ? coerceBoolean((patch as any).worldKeywordDeduplicateEnabled)

--- a/ui/src/stores/iform.ts
+++ b/ui/src/stores/iform.ts
@@ -1,9 +1,10 @@
 import { defineStore } from 'pinia';
-import { markRaw, watch } from 'vue';
+import { markRaw, watch, type EffectScope } from 'vue';
 import { api } from './_config';
 import { chatEvent, useChatStore } from './chat';
 import { useUserStore } from './user';
 import type { ChannelIForm, ChannelIFormEventPayload, ChannelIFormStatePayload } from '@/types/iform';
+import { ensureDetachedEffectScope } from './storeEffectScope';
 
 interface PanelState {
   windowId: string;
@@ -59,6 +60,7 @@ interface IFormStoreState {
 
 let gatewayBound = false;
 let gatewayHandler: ((event: any) => void) | null = null;
+let bootstrapScope: EffectScope | null = null;
 
 export const useIFormStore = defineStore('iform', {
   state: (): IFormStoreState => ({
@@ -139,31 +141,33 @@ export const useIFormStore = defineStore('iform', {
   },
   actions: {
     bootstrap() {
-      if (this.bootstrapped) {
+      if (this.bootstrapped && bootstrapScope?.active) {
         return;
       }
-      this.bootstrapped = true;
       const chat = useChatStore();
       const user = useUserStore();
-      watch(
-        () => chat.curChannel?.id,
-        (channelId) => {
-          this.setActiveChannel(channelId || null);
-          if (channelId) {
-            this.ensureForms(channelId);
-            this.refreshCapabilities(channelId);
-          }
-        },
-        { immediate: true },
-      );
-      watch(
-        () => user.info.id,
-        () => {
-          if (this.currentChannelId) {
-            this.refreshCapabilities(this.currentChannelId, true);
-          }
-        },
-      );
+      bootstrapScope = ensureDetachedEffectScope(bootstrapScope, () => {
+        watch(
+          () => chat.curChannel?.id,
+          (channelId) => {
+            this.setActiveChannel(channelId || null);
+            if (channelId) {
+              this.ensureForms(channelId);
+              this.refreshCapabilities(channelId);
+            }
+          },
+          { immediate: true },
+        );
+        watch(
+          () => user.info.id,
+          () => {
+            if (this.currentChannelId) {
+              this.refreshCapabilities(this.currentChannelId, true);
+            }
+          },
+        );
+      });
+      this.bootstrapped = true;
       if (!gatewayBound) {
         const store = this;
         gatewayHandler = (event: any) => store.handleGatewayEvent(event);

--- a/ui/src/stores/stickyNote.ts
+++ b/ui/src/stores/stickyNote.ts
@@ -836,6 +836,65 @@ export const useStickyNoteStore = defineStore('stickyNote', () => {
         }
     }
 
+    function parseStickyNoteUserIdSet(raw?: string) {
+        const result = new Set<string>()
+        const normalized = typeof raw === 'string' ? raw.trim() : ''
+        if (!normalized) return result
+        try {
+            const parsed = JSON.parse(normalized)
+            if (Array.isArray(parsed)) {
+                parsed.forEach((id) => {
+                    if (typeof id === 'string' && id.trim()) {
+                        result.add(id.trim())
+                    }
+                })
+                return result
+            }
+        } catch {
+            // ignore
+        }
+        normalized.split(',').forEach((id) => {
+            const trimmed = id.trim()
+            if (trimmed) {
+                result.add(trimmed)
+            }
+        })
+        return result
+    }
+
+    function canCurrentUserViewNote(note?: StickyNote | null) {
+        if (!note) return false
+        if (!note.visibility || note.visibility === 'all') {
+            return true
+        }
+        const userId = userStore.info?.id
+        if (!userId) {
+            return false
+        }
+        if (note.creatorId === userId || note.creator?.id === userId) {
+            return true
+        }
+        const editorIds = parseStickyNoteUserIdSet(note.editorIds)
+        if (editorIds.has(userId)) {
+            return true
+        }
+        switch (note.visibility) {
+            case 'owner':
+            case 'editors':
+                return false
+            case 'viewers':
+                return parseStickyNoteUserIdSet(note.viewerIds).has(userId)
+            default:
+                return true
+        }
+    }
+
+    function removeNoteFromLocalState(noteId: string) {
+        delete notes.value[noteId]
+        delete userStates.value[noteId]
+        closeNoteLocal(noteId)
+    }
+
     // 处理WebSocket事件
     function handleStickyNoteEvent(event: any) {
         const payload = event.stickyNote
@@ -846,20 +905,27 @@ export const useStickyNoteStore = defineStore('stickyNote', () => {
         switch (action) {
             case 'create':
                 if (note && note.channelId === currentChannelId.value) {
-                    notes.value[note.id] = note
-                    persistLocalCache()
+                    if (canCurrentUserViewNote(note)) {
+                        notes.value[note.id] = note
+                        persistLocalCache()
+                    } else {
+                        removeNoteFromLocalState(note.id)
+                    }
                 }
                 break
             case 'update':
-                if (note && notes.value[note.id]) {
-                    notes.value[note.id] = note
-                    persistLocalCache()
+                if (note && note.channelId === currentChannelId.value) {
+                    if (canCurrentUserViewNote(note)) {
+                        notes.value[note.id] = note
+                        persistLocalCache()
+                    } else {
+                        removeNoteFromLocalState(note.id)
+                    }
                 }
                 break
             case 'delete':
                 if (note) {
-                    delete notes.value[note.id]
-                    closeNoteLocal(note.id)
+                    removeNoteFromLocalState(note.id)
                 }
                 break
             case 'push':

--- a/ui/src/stores/storeEffectScope.ts
+++ b/ui/src/stores/storeEffectScope.ts
@@ -1,0 +1,15 @@
+import { effectScope, type EffectScope } from 'vue';
+
+export const ensureDetachedEffectScope = (
+  scope: EffectScope | null | undefined,
+  runner: () => void,
+): EffectScope => {
+  if (scope?.active) {
+    return scope;
+  }
+  const nextScope = effectScope(true);
+  nextScope.run(() => {
+    runner();
+  });
+  return nextScope;
+};

--- a/ui/src/types/audio.ts
+++ b/ui/src/types/audio.ts
@@ -59,7 +59,16 @@ export interface AdminAudioCleanupPreview {
   totalCandidates: number;
   safeCandidates: number;
   referencedSkipped: number;
+  directDeleteCandidates?: number;
+  detachThenDeleteCandidates?: number;
   items: AdminAudioAssetItem[];
+}
+
+export interface AudioDeleteImpact {
+  detachedSceneCount: number;
+  detachedPlaybackStateCount: number;
+  sceneNames?: string[];
+  playbackScopeLabels?: string[];
 }
 
 export interface AudioBulkDeleteFailure {
@@ -73,6 +82,10 @@ export interface AudioBulkDeleteResult {
   failed: AudioBulkDeleteFailure[];
   successCount: number;
   failedCount: number;
+  detachedSceneCount?: number;
+  detachedPlaybackStateCount?: number;
+  detachedReferencedAssetCount?: number;
+  playbackScopeLabels?: string[];
 }
 
 export interface AudioAssetMutationPayload {

--- a/ui/src/types/audio.ts
+++ b/ui/src/types/audio.ts
@@ -18,8 +18,61 @@ export interface AudioAsset {
   updatedBy?: string;
   createdAt: string;
   updatedAt: string;
+  lastAccessedAt?: string | null;
+  accessCount?: number;
   scope: AudioAssetScope;
   worldId?: string | null;
+}
+
+export interface AudioAssetUsageSummary {
+  sceneRefCount: number;
+  playbackStateRefCount: number;
+  sceneNames?: string[];
+  playbackScopeLabels?: string[];
+  referenced: boolean;
+}
+
+export interface AdminAudioFilterOption {
+  label: string;
+  value: string;
+}
+
+export interface AdminAudioAssetItem extends AudioAsset {
+  worldName?: string;
+  creatorName?: string;
+  accessCount: number;
+  usageSummary: AudioAssetUsageSummary;
+  safeToDelete: boolean;
+}
+
+export interface AdminAudioAssetListResult {
+  items: AdminAudioAssetItem[];
+  page: number;
+  pageSize: number;
+  total: number;
+  worldOptions: AdminAudioFilterOption[];
+  creatorOptions: AdminAudioFilterOption[];
+}
+
+export interface AdminAudioCleanupPreview {
+  thresholdBefore: string;
+  totalCandidates: number;
+  safeCandidates: number;
+  referencedSkipped: number;
+  items: AdminAudioAssetItem[];
+}
+
+export interface AudioBulkDeleteFailure {
+  assetId: string;
+  reason: string;
+  usageSummary?: AudioAssetUsageSummary;
+}
+
+export interface AudioBulkDeleteResult {
+  successIds: string[];
+  failed: AudioBulkDeleteFailure[];
+  successCount: number;
+  failedCount: number;
 }
 
 export interface AudioAssetMutationPayload {

--- a/ui/src/utils/displayWidth.ts
+++ b/ui/src/utils/displayWidth.ts
@@ -1,0 +1,94 @@
+export const WORLD_DESCRIPTION_MAX_DISPLAY_CHARS = 100;
+export const WORLD_DESCRIPTION_MAX_WIDTH_UNITS = WORLD_DESCRIPTION_MAX_DISPLAY_CHARS * 2;
+export const WORLD_DESCRIPTION_PREVIEW_MAX_WIDTH_UNITS = 66;
+export const WORLD_DESCRIPTION_PREVIEW_LINE_WIDTH_UNITS = 22;
+
+const isFullWidthCodePoint = (codePoint: number) => (
+  codePoint >= 0x1100 && (
+    codePoint <= 0x115f ||
+    codePoint === 0x2329 ||
+    codePoint === 0x232a ||
+    (codePoint >= 0x2e80 && codePoint <= 0x3247 && codePoint !== 0x303f) ||
+    (codePoint >= 0x3250 && codePoint <= 0x4dbf) ||
+    (codePoint >= 0x4e00 && codePoint <= 0xa4c6) ||
+    (codePoint >= 0xa960 && codePoint <= 0xa97c) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6b) ||
+    (codePoint >= 0xff01 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    (codePoint >= 0x1aff0 && codePoint <= 0x1aff3) ||
+    (codePoint >= 0x1aff5 && codePoint <= 0x1affb) ||
+    (codePoint >= 0x1affd && codePoint <= 0x1affe) ||
+    (codePoint >= 0x1b000 && codePoint <= 0x1b122) ||
+    codePoint === 0x1b132 ||
+    (codePoint >= 0x1b150 && codePoint <= 0x1b152) ||
+    (codePoint >= 0x1f200 && codePoint <= 0x1f23b) ||
+    (codePoint >= 0x1f240 && codePoint <= 0x1f248) ||
+    (codePoint >= 0x1f250 && codePoint <= 0x1f251) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  )
+);
+
+const getCodePointDisplayWidthUnits = (char: string) => {
+  const codePoint = char.codePointAt(0);
+  if (!codePoint) return 0;
+  return isFullWidthCodePoint(codePoint) ? 2 : 1;
+};
+
+export const getTextDisplayWidthUnits = (value: string) => {
+  let total = 0;
+  for (const char of value) {
+    total += getCodePointDisplayWidthUnits(char);
+  }
+  return total;
+};
+
+export const truncateTextByDisplayWidth = (value: string, maxUnits: number) => {
+  if (!value || maxUnits <= 0) return '';
+  let total = 0;
+  let result = '';
+  for (const char of value) {
+    const units = getCodePointDisplayWidthUnits(char);
+    if (total + units > maxUnits) break;
+    result += char;
+    total += units;
+  }
+  return result;
+};
+
+export const splitTextByDisplayWidth = (value: string, lineUnits: number) => {
+  if (!value) return [];
+  if (lineUnits <= 0) return [value];
+  const lines: string[] = [];
+  let currentLine = '';
+  let currentUnits = 0;
+
+  for (const char of value) {
+    if (char === '\n') {
+      lines.push(currentLine);
+      currentLine = '';
+      currentUnits = 0;
+      continue;
+    }
+
+    const units = getCodePointDisplayWidthUnits(char);
+    if (currentLine && currentUnits + units > lineUnits) {
+      lines.push(currentLine);
+      currentLine = char;
+      currentUnits = units;
+      continue;
+    }
+
+    currentLine += char;
+    currentUnits += units;
+  }
+
+  lines.push(currentLine);
+  return lines;
+};
+
+export const formatDisplayWidthAsCharCount = (units: number) => (
+  units % 2 === 0 ? String(units / 2) : `${Math.floor(units / 2)}.5`
+);

--- a/ui/src/utils/keywordTooltip.ts
+++ b/ui/src/utils/keywordTooltip.ts
@@ -13,6 +13,7 @@ import {
 import { isTargetWithinElement } from './keywordTooltipHoverBoundary'
 import { shouldReuseHoverTooltipForPin } from './keywordTooltipPinReuse'
 import { shouldHideTooltipBeforePositioning } from './keywordTooltipVisibility'
+import type { WorldKeywordTooltipInteractionPolicy } from './worldKeywordTooltipInteraction'
 
 interface TooltipContent {
   title: string
@@ -424,6 +425,7 @@ export interface KeywordTooltipOptions {
   onKeywordDoubleInvoke?: (keywordId: string) => void
   underlineOnly?: boolean
   textIndent?: number  // 多段首行缩进值（em），0 或未定义则不缩进
+  interaction?: WorldKeywordTooltipInteractionPolicy
   candidateLoader?: CandidateLoader
 }
 
@@ -458,6 +460,7 @@ export function createKeywordTooltip(
   const level = options?.level ?? 0
   const underlineOnly = options?.underlineOnly ?? false
   const textIndent = options?.textIndent ?? 0
+  const interaction = options?.interaction ?? { allowHoverOpen: true, allowClickOpen: true }
   let currentTooltip: TooltipInstance | null = null
   let currentSession: TooltipSession | null = null
   let hoverTooltipElement: HTMLDivElement | null = null
@@ -587,6 +590,7 @@ export function createKeywordTooltip(
         onKeywordDoubleInvoke: options?.onKeywordDoubleInvoke,
         underlineOnly: underlineOnly,
         textIndent: textIndent,
+        interaction,
       })
       nestedTooltipControllers.set(keywordId, controller)
     }
@@ -601,6 +605,10 @@ export function createKeywordTooltip(
 
     // Use event delegation on the tooltip element for nested keyword interactions
     tooltip.addEventListener('mouseover', (e) => {
+      if (!interaction.allowHoverOpen) {
+        return
+      }
+
       const target = e.target as HTMLElement
       const keywordSpan = target.closest('.keyword-highlight') as HTMLElement
       if (!keywordSpan) {
@@ -654,6 +662,10 @@ export function createKeywordTooltip(
 
       // If clicking on a nested keyword, handle it
       if (keywordSpan) {
+        if (!interaction.allowClickOpen) {
+          return
+        }
+
         const nestedKeywordId = keywordSpan.dataset.keywordId
         const currentKeywordId = getActiveKeywordId(currentSession)
         if (!nestedKeywordId || nestedKeywordId === currentKeywordId) return

--- a/ui/src/utils/observerRoleOptions.ts
+++ b/ui/src/utils/observerRoleOptions.ts
@@ -1,0 +1,41 @@
+import type { ChannelIcOocRoleConfig } from '../types'
+
+export interface ObserverRoleOption {
+  label: string
+  value: string
+}
+
+const resolveObserverRoleOrder = (
+  value: string,
+  config?: Partial<ChannelIcOocRoleConfig> | null,
+  rolelessValue = '__roleless__',
+) => {
+  if (value === rolelessValue) {
+    return 3
+  }
+  if (value && value === config?.icRoleId) {
+    return 0
+  }
+  if (value && value === config?.oocRoleId) {
+    return 1
+  }
+  return 2
+}
+
+export const sortObserverRoleOptions = (
+  options: ObserverRoleOption[],
+  config?: Partial<ChannelIcOocRoleConfig> | null,
+  rolelessValue = '__roleless__',
+) => {
+  return options
+    .map((item, index) => ({ item, index }))
+    .sort((left, right) => {
+      const leftOrder = resolveObserverRoleOrder(left.item.value, config, rolelessValue)
+      const rightOrder = resolveObserverRoleOrder(right.item.value, config, rolelessValue)
+      if (leftOrder !== rightOrder) {
+        return leftOrder - rightOrder
+      }
+      return left.index - right.index
+    })
+    .map(({ item }) => item)
+}

--- a/ui/src/utils/worldKeywordHighlighter.ts
+++ b/ui/src/utils/worldKeywordHighlighter.ts
@@ -6,6 +6,8 @@ import { applyKeywordTooltipSessionToElement } from './worldKeywordTooltipCandid
 interface HighlightOptions {
   underlineOnly: boolean
   deduplicate?: boolean
+  allowHoverOpen?: boolean
+  allowClickOpen?: boolean
   onKeywordDoubleInvoke?: (keywordId: string) => void
 }
 
@@ -232,131 +234,158 @@ function wrapRanges(
   node.replaceWith(fragment)
 }
 
+interface DelegatedContainerState {
+  options: HighlightOptions
+  tooltip?: KeywordTooltipController
+  currentHoveredSpan: HTMLElement | null
+}
+
 // WeakMap to track delegated event listeners per container
-const delegatedContainers = new WeakMap<HTMLElement, boolean>()
+const delegatedContainers = new WeakMap<HTMLElement, DelegatedContainerState>()
 
 function setupEventDelegation(
   root: HTMLElement,
   options: HighlightOptions,
   tooltip?: KeywordTooltipController,
 ) {
-  // Skip if already delegated
-  if (delegatedContainers.has(root)) {
+  const existingState = delegatedContainers.get(root)
+  if (existingState) {
+    existingState.options = options
+    existingState.tooltip = tooltip
+    if (!tooltip) {
+      existingState.currentHoveredSpan = null
+    }
     return
   }
-  delegatedContainers.set(root, true)
+
+  const state: DelegatedContainerState = {
+    options,
+    tooltip,
+    currentHoveredSpan: null,
+  }
+  delegatedContainers.set(root, state)
 
   // Hover events (using capture for mouseenter/leave)
-  if (tooltip) {
-    let currentHoveredSpan: HTMLElement | null = null
+  root.addEventListener('mouseover', (e) => {
+    const tooltipController = state.tooltip
+    if (!tooltipController || !state.options.allowHoverOpen) return
 
-    root.addEventListener('mouseover', (e) => {
-      const span = (e.target as HTMLElement).closest<HTMLElement>(`span.${HIGHLIGHT_CLASS}`)
-      if (span && root.contains(span)) {
-        currentHoveredSpan = span
-        const keywordId = span.dataset.keywordId
-        if (keywordId) {
-          tooltip.show(span, keywordId)
-        }
-      }
-    })
-
-    root.addEventListener('mouseout', (e) => {
-      const span = (e.target as HTMLElement).closest<HTMLElement>(`span.${HIGHLIGHT_CLASS}`)
-      if (!span || !root.contains(span)) return
-
-      const relatedTarget = (e as MouseEvent).relatedTarget as HTMLElement | null
-      if (!shouldKeepKeywordTooltipOpenOnTransition({
-        root,
-        relatedTarget,
-        hoverTooltip: tooltip.getHoverTooltipElement(),
-      })) {
-        tooltip.hide(span)
-        currentHoveredSpan = null
-      }
-    })
-
-    root.addEventListener('mouseleave', (e) => {
-      if (!currentHoveredSpan) {
-        return
-      }
-
-      const relatedTarget = (e as MouseEvent).relatedTarget as HTMLElement | null
-      if (!shouldKeepKeywordTooltipOpenOnTransition({
-        root,
-        relatedTarget,
-        hoverTooltip: tooltip.getHoverTooltipElement(),
-      })) {
-        tooltip.hide(currentHoveredSpan)
-        currentHoveredSpan = null
-      }
-    })
-
-    // Click for pin (on highlight) or hide all (on non-highlight)
-    root.addEventListener('click', (e) => {
-      const span = (e.target as HTMLElement).closest<HTMLElement>(`span.${HIGHLIGHT_CLASS}`)
-
-      // If clicking outside highlight area, hide all tooltips as fallback
-      if (!span || !root.contains(span)) {
-        tooltip.hideAll()
-        return
-      }
-
+    const span = (e.target as HTMLElement).closest<HTMLElement>(`span.${HIGHLIGHT_CLASS}`)
+    if (span && root.contains(span)) {
+      state.currentHoveredSpan = span
       const keywordId = span.dataset.keywordId
-      if (!keywordId) return
-
-      e.preventDefault()
-      e.stopPropagation()
-
-      // Handle double-click detection
-      if (clickState.timer && clickState.target === span && clickState.keywordId === keywordId) {
-        clearTimeout(clickState.timer)
-        clickState.timer = null
-        clickState.target = null
-        clickState.keywordId = null
-        if (options.onKeywordDoubleInvoke) {
-          options.onKeywordDoubleInvoke(keywordId)
-        }
-        return
+      if (keywordId) {
+        tooltipController.show(span, keywordId)
       }
+    }
+  })
 
-      if (clickState.timer) {
-        clearTimeout(clickState.timer)
+  root.addEventListener('mouseout', (e) => {
+    const tooltipController = state.tooltip
+    if (!tooltipController || !state.options.allowHoverOpen) return
+
+    const span = (e.target as HTMLElement).closest<HTMLElement>(`span.${HIGHLIGHT_CLASS}`)
+    if (!span || !root.contains(span)) return
+
+    const relatedTarget = (e as MouseEvent).relatedTarget as HTMLElement | null
+    if (!shouldKeepKeywordTooltipOpenOnTransition({
+      root,
+      relatedTarget,
+      hoverTooltip: tooltipController.getHoverTooltipElement(),
+    })) {
+      tooltipController.hide(span)
+      state.currentHoveredSpan = null
+    }
+  })
+
+  root.addEventListener('mouseleave', (e) => {
+    const tooltipController = state.tooltip
+    if (!tooltipController || !state.options.allowHoverOpen || !state.currentHoveredSpan) {
+      return
+    }
+
+    const relatedTarget = (e as MouseEvent).relatedTarget as HTMLElement | null
+    if (!shouldKeepKeywordTooltipOpenOnTransition({
+      root,
+      relatedTarget,
+      hoverTooltip: tooltipController.getHoverTooltipElement(),
+    })) {
+      tooltipController.hide(state.currentHoveredSpan)
+      state.currentHoveredSpan = null
+    }
+  })
+
+  // Click for pin (on highlight) or hide all (on non-highlight)
+  root.addEventListener('click', (e) => {
+    const tooltipController = state.tooltip
+    if (!tooltipController) return
+
+    const span = (e.target as HTMLElement).closest<HTMLElement>(`span.${HIGHLIGHT_CLASS}`)
+
+    // If clicking outside highlight area, hide all tooltips as fallback
+    if (!span || !root.contains(span)) {
+      tooltipController.hideAll()
+      return
+    }
+
+    if (!state.options.allowClickOpen) {
+      return
+    }
+
+    const keywordId = span.dataset.keywordId
+    if (!keywordId) return
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    // Handle double-click detection
+    if (clickState.timer && clickState.target === span && clickState.keywordId === keywordId) {
+      clearTimeout(clickState.timer)
+      clickState.timer = null
+      clickState.target = null
+      clickState.keywordId = null
+      if (state.options.onKeywordDoubleInvoke) {
+        state.options.onKeywordDoubleInvoke(keywordId)
       }
+      return
+    }
 
-      clickState.target = span
-      clickState.keywordId = keywordId
-      clickState.timer = setTimeout(() => {
-        tooltip.pin(span, keywordId)
-        clickState.timer = null
-        clickState.target = null
-        clickState.keywordId = null
-      }, DOUBLE_CLICK_DELAY)
-    })
-  }
+    if (clickState.timer) {
+      clearTimeout(clickState.timer)
+    }
+
+    clickState.target = span
+    clickState.keywordId = keywordId
+    clickState.timer = setTimeout(() => {
+      tooltipController.pin(span, keywordId)
+      clickState.timer = null
+      clickState.target = null
+      clickState.keywordId = null
+    }, DOUBLE_CLICK_DELAY)
+  })
 
   // Double click for edit
-  if (options.onKeywordDoubleInvoke) {
-    root.addEventListener('dblclick', (e) => {
-      const span = (e.target as HTMLElement).closest<HTMLElement>(`span.${HIGHLIGHT_CLASS}`)
-      if (!span || !root.contains(span)) return
+  root.addEventListener('dblclick', (e) => {
+    if (!state.options.onKeywordDoubleInvoke) return
 
-      const keywordId = span.dataset.keywordId
-      if (!keywordId) return
+    const span = (e.target as HTMLElement).closest<HTMLElement>(`span.${HIGHLIGHT_CLASS}`)
+    if (!span || !root.contains(span)) return
 
-      e.preventDefault()
-      e.stopPropagation()
+    const keywordId = span.dataset.keywordId
+    if (!keywordId) return
 
-      if (clickState.timer) {
-        clearTimeout(clickState.timer)
-        clickState.timer = null
-        clickState.target = null
-        clickState.keywordId = null
-      }
+    e.preventDefault()
+    e.stopPropagation()
 
-      options.onKeywordDoubleInvoke!(keywordId)
-    })
-  }
+    if (clickState.timer) {
+      clearTimeout(clickState.timer)
+      clickState.timer = null
+      clickState.target = null
+      clickState.keywordId = null
+    }
+
+    state.options.onKeywordDoubleInvoke(keywordId)
+  })
 }
 
 export function refreshWorldKeywordHighlights(
@@ -366,14 +395,12 @@ export function refreshWorldKeywordHighlights(
   tooltip?: KeywordTooltipController,
 ) {
   if (!root) return
+  setupEventDelegation(root, options, tooltip)
   if (!compiled?.length) {
     clearExistingHighlights(root)
     return
   }
   clearExistingHighlights(root)
-
-  // Setup event delegation once per container
-  setupEventDelegation(root, options, tooltip)
 
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
   const nodes: Text[] = []

--- a/ui/src/utils/worldKeywordTooltipInteraction.ts
+++ b/ui/src/utils/worldKeywordTooltipInteraction.ts
@@ -1,0 +1,42 @@
+export interface WorldKeywordTooltipInteractionSettings {
+  tooltipEnabled: boolean
+  hoverEnabled: boolean
+  clickEnabled: boolean
+}
+
+export interface WorldKeywordTooltipInteractionPolicy {
+  allowHoverOpen: boolean
+  allowClickOpen: boolean
+}
+
+export const DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION: WorldKeywordTooltipInteractionSettings = {
+  tooltipEnabled: true,
+  hoverEnabled: true,
+  clickEnabled: true,
+}
+
+const coerceBoolean = (value: unknown, fallback: boolean): boolean => (
+  typeof value === 'boolean' ? value : fallback
+)
+
+export function normalizeWorldKeywordTooltipInteractionSettings(
+  value?: Partial<WorldKeywordTooltipInteractionSettings> | null,
+): WorldKeywordTooltipInteractionSettings {
+  return {
+    tooltipEnabled: coerceBoolean(value?.tooltipEnabled, DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.tooltipEnabled),
+    hoverEnabled: coerceBoolean(value?.hoverEnabled, DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.hoverEnabled),
+    clickEnabled: coerceBoolean(value?.clickEnabled, DEFAULT_WORLD_KEYWORD_TOOLTIP_INTERACTION.clickEnabled),
+  }
+}
+
+export function resolveWorldKeywordTooltipInteractionPolicy(
+  value: WorldKeywordTooltipInteractionSettings & { finePointer: boolean },
+): WorldKeywordTooltipInteractionPolicy {
+  const settings = normalizeWorldKeywordTooltipInteractionSettings(value)
+  const tooltipEnabled = settings.tooltipEnabled
+
+  return {
+    allowHoverOpen: tooltipEnabled && settings.hoverEnabled && value.finePointer,
+    allowClickOpen: tooltipEnabled && settings.clickEnabled,
+  }
+}

--- a/ui/src/views/admin/admin-settings-audio.vue
+++ b/ui/src/views/admin/admin-settings-audio.vue
@@ -1,0 +1,1015 @@
+<script setup lang="ts">
+import { api } from '@/stores/_config';
+import type {
+  AdminAudioAssetItem,
+  AdminAudioAssetListResult,
+  AdminAudioCleanupPreview,
+  AdminAudioFilterOption,
+  AudioAssetUsageSummary,
+  AudioBulkDeleteFailure,
+  AudioBulkDeleteResult,
+} from '@/types/audio';
+import { Search, Refresh, Trash } from '@vicons/tabler';
+import { NButton, NTag, useDialog, useMessage, type DataTableColumns } from 'naive-ui';
+import { computed, h, onMounted, ref } from 'vue';
+
+type AdminAudioSearchField = 'all' | 'name' | 'worldName' | 'creatorName';
+type AdminAudioSortField = 'updatedAt' | 'name' | 'scope' | 'worldName' | 'creatorName' | 'size' | 'lastAccessedAt';
+
+const message = useMessage();
+const dialog = useDialog();
+
+const loading = ref(false);
+const rows = ref<AdminAudioAssetItem[]>([]);
+const total = ref(0);
+const page = ref(1);
+const pageSize = ref(20);
+const keyword = ref('');
+const selectedScope = ref<'all' | 'common' | 'world'>('all');
+const selectedWorldId = ref<string | null>(null);
+const selectedCreatorId = ref<string | null>(null);
+const selectedReferenced = ref<'all' | 'yes' | 'no'>('all');
+const selectedNeverAccessed = ref<'all' | 'yes' | 'no'>('all');
+const inactiveDays = ref<number | null>(null);
+const activeSearchField = ref<AdminAudioSearchField>('all');
+const sortBy = ref<AdminAudioSortField>('updatedAt');
+const sortOrder = ref<'asc' | 'desc'>('desc');
+const worldOptions = ref<AdminAudioFilterOption[]>([]);
+const creatorOptions = ref<AdminAudioFilterOption[]>([]);
+const checkedRowKeys = ref<string[]>([]);
+const selectedAssetId = ref<string | null>(null);
+const detailModalVisible = ref(false);
+
+const cleanupModalVisible = ref(false);
+const cleanupLoading = ref(false);
+const cleanupDays = ref<number>(30);
+const cleanupPreview = ref<AdminAudioCleanupPreview | null>(null);
+
+let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+const selectedAsset = computed(() => rows.value.find((item) => item.id === selectedAssetId.value) || null);
+const selectionCount = computed(() => checkedRowKeys.value.length);
+const hasSelection = computed(() => selectionCount.value > 0);
+const cleanupThresholdText = computed(() => (cleanupPreview.value ? formatDate(cleanupPreview.value.thresholdBefore) : ''));
+const selectedSceneNames = computed(() => selectedAsset.value?.usageSummary?.sceneNames || []);
+const selectedPlaybackLabels = computed(() => selectedAsset.value?.usageSummary?.playbackScopeLabels || []);
+const canExecuteCleanup = computed(() => Boolean(cleanupPreview.value?.safeCandidates));
+const searchFieldLabelMap: Record<AdminAudioSearchField, string> = {
+  all: '全部字段',
+  name: '名称',
+  worldName: '所属世界',
+  creatorName: '上传者',
+};
+const searchPlaceholder = computed(() => (
+  activeSearchField.value === 'all'
+    ? '搜索名称 / 备注 / 标签'
+    : `仅搜索${searchFieldLabelMap[activeSearchField.value]}`
+));
+const activeSearchLabel = computed(() => searchFieldLabelMap[activeSearchField.value]);
+
+const scopeOptions = [
+  { label: '全部级别', value: 'all' },
+  { label: '通用级', value: 'common' },
+  { label: '世界级', value: 'world' },
+];
+
+const referencedOptions = [
+  { label: '全部引用状态', value: 'all' },
+  { label: '已被引用', value: 'yes' },
+  { label: '未被引用', value: 'no' },
+];
+
+const neverAccessedOptions = [
+  { label: '全部访问状态', value: 'all' },
+  { label: '从未访问', value: 'yes' },
+  { label: '已有访问记录', value: 'no' },
+];
+
+const cleanupDayOptions = [
+  { label: '7 天', value: 7 },
+  { label: '30 天', value: 30 },
+  { label: '90 天', value: 90 },
+  { label: '180 天', value: 180 },
+];
+
+function renderHeaderTrigger(label: string, field: AdminAudioSortField, searchField?: AdminAudioSearchField) {
+  const sortActive = sortBy.value === field;
+  const searchActive = Boolean(searchField && activeSearchField.value === searchField);
+  const sortGlyph = sortActive ? (sortOrder.value === 'asc' ? '↑' : '↓') : '↕';
+  return h(
+    'button',
+    {
+      class: [
+        'admin-audio__header-trigger',
+        sortActive && 'admin-audio__header-trigger--sorted',
+        searchActive && 'admin-audio__header-trigger--searching',
+      ],
+      type: 'button',
+      onClick: () => handleHeaderTrigger(field, searchField),
+    },
+    [
+      h('span', { class: 'admin-audio__header-label' }, label),
+      searchField ? h('span', { class: 'admin-audio__header-search-indicator' }, '筛') : null,
+      h('span', { class: 'admin-audio__header-sort-indicator' }, sortGlyph),
+    ],
+  );
+}
+
+const columns = computed<DataTableColumns<AdminAudioAssetItem>>(() => [
+  {
+    type: 'selection',
+    disabled: (row) => !row.safeToDelete,
+  },
+  {
+    title: () => renderHeaderTrigger('名称', 'name', 'name'),
+    key: 'name',
+    minWidth: 280,
+    render: (row) => h('div', { class: 'admin-audio__name-cell' }, [
+      h(
+        'button',
+        {
+          class: 'admin-audio__name-button',
+          type: 'button',
+          onClick: (event: MouseEvent) => {
+            event.stopPropagation();
+            openDetail(row);
+          },
+        },
+        row.name,
+      ),
+      row.description ? h('p', { class: 'admin-audio__desc' }, row.description) : null,
+    ]),
+  },
+  {
+    title: () => renderHeaderTrigger('级别', 'scope'),
+    key: 'scope',
+    width: 90,
+    render: (row) => h(
+      NTag,
+      { size: 'small', type: row.scope === 'common' ? 'info' : 'warning' },
+      { default: () => (row.scope === 'common' ? '通用级' : '世界级') },
+    ),
+  },
+  {
+    title: () => renderHeaderTrigger('所属世界', 'worldName', 'worldName'),
+    key: 'worldName',
+    width: 160,
+    render: (row) => row.worldName || '全局',
+  },
+  {
+    title: () => renderHeaderTrigger('上传者', 'creatorName', 'creatorName'),
+    key: 'creatorName',
+    width: 140,
+    render: (row) => row.creatorName || row.createdBy,
+  },
+  {
+    title: () => renderHeaderTrigger('大小', 'size'),
+    key: 'size',
+    width: 120,
+    render: (row) => formatFileSize(row.size),
+  },
+  {
+    title: () => renderHeaderTrigger('修改时间', 'updatedAt'),
+    key: 'updatedAt',
+    width: 160,
+    render: (row) => formatDate(row.updatedAt),
+  },
+  {
+    title: () => renderHeaderTrigger('最近访问', 'lastAccessedAt'),
+    key: 'lastAccessedAt',
+    width: 160,
+    render: (row) => formatAccessTime(row.lastAccessedAt),
+  },
+  {
+    title: '状态',
+    key: 'usageSummary',
+    width: 128,
+    render: (row) => h('div', { class: 'admin-audio__usage-cell' }, [
+      h(
+        NTag,
+        { size: 'small', type: row.safeToDelete ? 'success' : 'error' },
+        { default: () => (row.safeToDelete ? '可安全删除' : '仍被引用') },
+      ),
+    ]),
+  },
+  {
+    title: '操作',
+    key: 'actions',
+    width: 150,
+    render: (row) => h('div', { class: 'admin-audio__action-cell' }, [
+      h(
+        NButton,
+        {
+          size: 'small',
+          tertiary: true,
+          onClick: () => openDetail(row),
+        },
+        { default: () => '查看信息' },
+      ),
+      h(
+        NButton,
+        {
+          size: 'small',
+          tertiary: true,
+          type: 'error',
+          disabled: !row.safeToDelete,
+          onClick: () => confirmDelete(row),
+        },
+        { default: () => '删除' },
+      ),
+    ]),
+  },
+]);
+
+const cleanupColumns = computed<DataTableColumns<AdminAudioAssetItem>>(() =>
+  columns.value.filter((column) => (column as any).type !== 'selection' && (column as any).key !== 'actions'),
+);
+
+onMounted(() => {
+  void refresh();
+});
+
+function buildListParams() {
+  return {
+    page: page.value,
+    pageSize: pageSize.value,
+    query: keyword.value.trim() || undefined,
+    queryField: activeSearchField.value === 'all' ? undefined : activeSearchField.value,
+    sortBy: sortBy.value,
+    sortOrder: sortOrder.value,
+    scope: selectedScope.value === 'all' ? undefined : selectedScope.value,
+    worldId: selectedWorldId.value || undefined,
+    creatorId: selectedCreatorId.value || undefined,
+    referenced:
+      selectedReferenced.value === 'all'
+        ? undefined
+        : selectedReferenced.value === 'yes',
+    neverAccessed:
+      selectedNeverAccessed.value === 'all'
+        ? undefined
+        : selectedNeverAccessed.value === 'yes',
+    inactiveDays: inactiveDays.value || undefined,
+  };
+}
+
+async function refresh() {
+  loading.value = true;
+  try {
+    const resp = await api.get<AdminAudioAssetListResult>('/api/v1/admin/audio-assets', {
+      params: buildListParams(),
+    });
+    rows.value = resp.data.items || [];
+    total.value = resp.data.total || 0;
+    worldOptions.value = resp.data.worldOptions || [];
+    creatorOptions.value = resp.data.creatorOptions || [];
+    const validSelection = new Set(rows.value.filter((item) => item.safeToDelete).map((item) => item.id));
+    checkedRowKeys.value = checkedRowKeys.value.filter((item) => validSelection.has(item));
+    if (selectedAssetId.value && rows.value.some((item) => item.id === selectedAssetId.value)) {
+      return;
+    }
+    selectedAssetId.value = rows.value[0]?.id ?? null;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function handleSearchInput() {
+  if (searchTimer) clearTimeout(searchTimer);
+  searchTimer = setTimeout(() => {
+    page.value = 1;
+    void refresh();
+  }, 250);
+}
+
+function applyFilters() {
+  page.value = 1;
+  void refresh();
+}
+
+function handleHeaderTrigger(field: AdminAudioSortField, searchField?: AdminAudioSearchField) {
+  if (searchField) {
+    activeSearchField.value = searchField;
+  }
+  if (sortBy.value === field) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc';
+  } else {
+    sortBy.value = field;
+    sortOrder.value = field === 'updatedAt' || field === 'lastAccessedAt' || field === 'size' ? 'desc' : 'asc';
+  }
+  page.value = 1;
+  void refresh();
+}
+
+function clearColumnSearchField() {
+  activeSearchField.value = 'all';
+  page.value = 1;
+  void refresh();
+}
+
+function resetFilters() {
+  keyword.value = '';
+  activeSearchField.value = 'all';
+  sortBy.value = 'updatedAt';
+  sortOrder.value = 'desc';
+  selectedScope.value = 'all';
+  selectedWorldId.value = null;
+  selectedCreatorId.value = null;
+  selectedReferenced.value = 'all';
+  selectedNeverAccessed.value = 'all';
+  inactiveDays.value = null;
+  page.value = 1;
+  void refresh();
+}
+
+function handlePageChange(nextPage: number) {
+  page.value = nextPage;
+  void refresh();
+}
+
+function handlePageSizeChange(nextPageSize: number) {
+  pageSize.value = nextPageSize;
+  page.value = 1;
+  void refresh();
+}
+
+function handleCheckedRowKeysChange(keys: Array<string | number>) {
+  checkedRowKeys.value = keys.map((key) => String(key));
+}
+
+function selectRow(row: AdminAudioAssetItem) {
+  selectedAssetId.value = row.id;
+}
+
+function openDetail(row: AdminAudioAssetItem) {
+  selectRow(row);
+  detailModalVisible.value = true;
+}
+
+function rowProps(row: AdminAudioAssetItem) {
+  return {
+    style: 'cursor: pointer;',
+    onClick: () => selectRow(row),
+    onDblclick: () => openDetail(row),
+  };
+}
+
+function formatFileSize(value?: number) {
+  const size = value ?? 0;
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  if (size < 1024 * 1024 * 1024) return `${(size / 1024 / 1024).toFixed(1)} MB`;
+  return `${(size / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function formatDuration(value?: number) {
+  const seconds = Math.max(0, Math.floor(value ?? 0));
+  const minutes = Math.floor(seconds / 60);
+  const remain = seconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(remain).padStart(2, '0')}`;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return '未知';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '未知';
+  return date.toLocaleString();
+}
+
+function formatAccessTime(value?: string | null) {
+  if (!value) return '从未记录访问';
+  return formatDate(value);
+}
+
+function resolveUsageSummaryText(usage?: AudioAssetUsageSummary | null) {
+  const sceneCount = usage?.sceneRefCount || 0;
+  const playbackCount = usage?.playbackStateRefCount || 0;
+  if (!sceneCount && !playbackCount) {
+    return '未被场景或当前播放引用';
+  }
+  return `场景 ${sceneCount} / 播放状态 ${playbackCount}`;
+}
+
+function resolveUsageText(row: AdminAudioAssetItem) {
+  return resolveUsageSummaryText(row.usageSummary);
+}
+
+function buildFailureSummary(failed: AudioBulkDeleteFailure[] = []) {
+  if (!failed.length) return '';
+  const lines = failed.slice(0, 5).map((item) => {
+    const usageText = item.usageSummary ? resolveUsageSummaryText(item.usageSummary) : '';
+    return `${item.assetId}：${item.reason}${usageText ? `（${usageText}）` : ''}`;
+  });
+  if (failed.length > 5) {
+    lines.push(`其余 ${failed.length - 5} 条失败素材请结合筛选条件重新查看列表。`);
+  }
+  return lines.join('\n');
+}
+
+function openFailureDialog(title: string, failed: AudioBulkDeleteFailure[] = []) {
+  if (!failed.length) return;
+  dialog.warning({
+    title,
+    content: buildFailureSummary(failed),
+    positiveText: '知道了',
+  });
+}
+
+function openReferencedDialog(assetName: string, usage?: AudioAssetUsageSummary) {
+  dialog.warning({
+    title: '素材仍被引用',
+    content: `“${assetName}” 当前无法删除。${usage ? `引用情况：${resolveUsageSummaryText(usage)}` : ''}`,
+    positiveText: '知道了',
+  });
+}
+
+function extractErrorMessage(error: any, fallback: string) {
+  return error?.response?.data?.message || error?.response?.data?.error || error?.message || fallback;
+}
+
+function confirmDelete(row: AdminAudioAssetItem) {
+  dialog.warning({
+    title: '安全删除音频素材',
+    content: `确定删除“${row.name}”吗？该操作会执行引用检查。`,
+    positiveText: '删除',
+    negativeText: '取消',
+    onPositiveClick: async () => {
+      try {
+        await api.delete(`/api/v1/admin/audio-assets/${row.id}`);
+        message.success('素材已删除');
+        checkedRowKeys.value = checkedRowKeys.value.filter((item) => item !== row.id);
+        await refresh();
+      } catch (error) {
+        const requestError = error as any;
+        if (requestError?.response?.status === 409) {
+          openReferencedDialog(row.name, requestError?.response?.data?.usage);
+        }
+        message.error(extractErrorMessage(requestError, '删除失败'));
+      }
+    },
+  });
+}
+
+function confirmBulkDelete() {
+  if (!checkedRowKeys.value.length) return;
+  dialog.warning({
+    title: '批量安全删除',
+    content: `确定删除选中的 ${checkedRowKeys.value.length} 条素材吗？`,
+    positiveText: '删除',
+    negativeText: '取消',
+    onPositiveClick: async () => {
+      try {
+        const resp = await api.post<AudioBulkDeleteResult>('/api/v1/admin/audio-assets/bulk-delete', {
+          ids: checkedRowKeys.value,
+        });
+        const successCount = resp.data?.successCount || 0;
+        const failedCount = resp.data?.failedCount || 0;
+        if (successCount) {
+          message.success(`已删除 ${successCount} 条素材`);
+        }
+        if (failedCount) {
+          message.warning(`${failedCount} 条素材删除失败`);
+          openFailureDialog('批量删除失败详情', resp.data?.failed || []);
+        }
+        checkedRowKeys.value = [];
+        await refresh();
+      } catch (error) {
+        message.error(extractErrorMessage(error, '批量删除失败'));
+      }
+    },
+  });
+}
+
+async function loadCleanupPreview() {
+  cleanupLoading.value = true;
+  try {
+    const resp = await api.get<AdminAudioCleanupPreview>('/api/v1/admin/audio-assets/cleanup-preview', {
+      params: {
+        days: cleanupDays.value,
+        query: keyword.value.trim() || undefined,
+        queryField: activeSearchField.value === 'all' ? undefined : activeSearchField.value,
+        sortBy: sortBy.value,
+        sortOrder: sortOrder.value,
+        scope: selectedScope.value === 'all' ? undefined : selectedScope.value,
+        worldId: selectedWorldId.value || undefined,
+        creatorId: selectedCreatorId.value || undefined,
+      },
+    });
+    cleanupPreview.value = resp.data;
+  } catch (error) {
+    message.error(extractErrorMessage(error, '读取清理预览失败'));
+  } finally {
+    cleanupLoading.value = false;
+  }
+}
+
+async function executeCleanup() {
+  cleanupLoading.value = true;
+  try {
+    const resp = await api.post<AudioBulkDeleteResult>('/api/v1/admin/audio-assets/cleanup', {
+      days: cleanupDays.value,
+      query: keyword.value.trim() || undefined,
+      queryField: activeSearchField.value === 'all' ? undefined : activeSearchField.value,
+      sortBy: sortBy.value,
+      sortOrder: sortOrder.value,
+      scope: selectedScope.value === 'all' ? undefined : selectedScope.value,
+      worldId: selectedWorldId.value || undefined,
+      creatorId: selectedCreatorId.value || undefined,
+    });
+    const successCount = resp.data?.successCount || 0;
+    const failedCount = resp.data?.failedCount || 0;
+    if (successCount) {
+      message.success(`已清理 ${successCount} 条素材`);
+    } else {
+      message.info('没有可清理的素材');
+    }
+    if (failedCount) {
+      message.warning(`${failedCount} 条素材因引用或其他原因未删除`);
+      openFailureDialog('安全清理失败详情', resp.data?.failed || []);
+    }
+    cleanupModalVisible.value = false;
+    cleanupPreview.value = null;
+    checkedRowKeys.value = [];
+    await refresh();
+  } catch (error) {
+    message.error(extractErrorMessage(error, '执行清理失败'));
+  } finally {
+    cleanupLoading.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="admin-audio">
+    <div class="admin-audio__toolbar">
+      <div class="admin-audio__filters">
+        <n-input
+          v-model:value="keyword"
+          clearable
+          :placeholder="searchPlaceholder"
+          @input="handleSearchInput"
+          @clear="handleSearchInput"
+        >
+          <template #prefix>
+            <n-icon :component="Search" />
+          </template>
+        </n-input>
+
+        <n-tag size="small" :type="activeSearchField === 'all' ? 'default' : 'info'">
+          搜索列：{{ activeSearchLabel }}
+        </n-tag>
+
+        <n-button v-if="activeSearchField !== 'all'" quaternary size="small" @click="clearColumnSearchField">
+          清除列筛选
+        </n-button>
+
+        <n-select
+          v-model:value="selectedScope"
+          :options="scopeOptions"
+          style="width: 120px"
+          @update:value="applyFilters"
+        />
+
+        <n-select
+          v-model:value="selectedWorldId"
+          clearable
+          filterable
+          :options="worldOptions"
+          placeholder="所属世界"
+          style="width: 180px"
+          @update:value="applyFilters"
+        />
+
+        <n-select
+          v-model:value="selectedCreatorId"
+          clearable
+          filterable
+          :options="creatorOptions"
+          placeholder="上传者"
+          style="width: 160px"
+          @update:value="applyFilters"
+        />
+
+        <n-select
+          v-model:value="selectedReferenced"
+          :options="referencedOptions"
+          style="width: 140px"
+          @update:value="applyFilters"
+        />
+
+        <n-select
+          v-model:value="selectedNeverAccessed"
+          :options="neverAccessedOptions"
+          style="width: 140px"
+          @update:value="applyFilters"
+        />
+
+        <n-input-number
+          v-model:value="inactiveDays"
+          clearable
+          :min="1"
+          placeholder="超过 N 天未访问"
+          style="width: 170px"
+          @update:value="applyFilters"
+        />
+      </div>
+
+      <div class="admin-audio__actions">
+        <n-button @click="refresh" :loading="loading">
+          <template #icon>
+            <n-icon :component="Refresh" />
+          </template>
+          刷新
+        </n-button>
+        <n-button @click="resetFilters">重置筛选</n-button>
+        <n-button :disabled="!hasSelection" type="error" @click="confirmBulkDelete">
+          <template #icon>
+            <n-icon :component="Trash" />
+          </template>
+          批量删除
+        </n-button>
+        <n-button type="warning" @click="cleanupModalVisible = true; cleanupPreview = null">
+          <template #icon>
+            <n-icon :component="Trash" />
+          </template>
+          清理未使用素材
+        </n-button>
+      </div>
+    </div>
+
+    <div class="admin-audio__stats">
+      共 <n-text type="primary">{{ total }}</n-text> 条素材
+      <span v-if="hasSelection">，已选 {{ selectionCount }} 条</span>
+    </div>
+
+    <div class="admin-audio__content">
+      <div class="admin-audio__table-card">
+        <div class="admin-audio__table-scroll">
+          <n-data-table
+            :columns="columns"
+            :data="rows"
+            :loading="loading"
+            :pagination="false"
+            :checked-row-keys="checkedRowKeys"
+            :row-key="(row: AdminAudioAssetItem) => row.id"
+            :row-props="rowProps"
+            size="small"
+            :scroll-x="1520"
+            :max-height="520"
+            @update:checked-row-keys="handleCheckedRowKeysChange"
+          />
+        </div>
+        <div class="admin-audio__pagination">
+          <n-pagination
+            v-model:page="page"
+            v-model:page-size="pageSize"
+            :item-count="total"
+            :page-sizes="[10, 20, 50, 100]"
+            show-size-picker
+            show-quick-jumper
+            :on-update:page="handlePageChange"
+            :on-update:page-size="handlePageSizeChange"
+          >
+            <template #prefix="{ itemCount }">
+              共 {{ itemCount }} 条
+            </template>
+          </n-pagination>
+        </div>
+      </div>
+    </div>
+
+    <n-modal v-model:show="detailModalVisible" preset="card" title="音频素材信息" class="admin-audio__detail-modal" :style="{ width: 'min(760px, 92vw)' }">
+      <template v-if="selectedAsset">
+        <div class="admin-audio__detail-header">
+          <div>
+            <h3>{{ selectedAsset.name }}</h3>
+            <p>{{ selectedAsset.worldName || '全局素材' }}</p>
+          </div>
+          <n-tag :type="selectedAsset.safeToDelete ? 'success' : 'error'">
+            {{ selectedAsset.safeToDelete ? '可安全删除' : '仍被引用' }}
+          </n-tag>
+        </div>
+
+        <n-descriptions label-placement="top" :column="2" size="small" bordered>
+          <n-descriptions-item label="上传者">
+            {{ selectedAsset.creatorName || selectedAsset.createdBy }}
+          </n-descriptions-item>
+          <n-descriptions-item label="作用域">
+            {{ selectedAsset.scope === 'common' ? '通用级' : '世界级' }}
+          </n-descriptions-item>
+          <n-descriptions-item label="文件大小">
+            {{ formatFileSize(selectedAsset.size) }}
+          </n-descriptions-item>
+          <n-descriptions-item label="音频时长">
+            {{ formatDuration(selectedAsset.duration) }}
+          </n-descriptions-item>
+          <n-descriptions-item label="最近访问">
+            {{ formatAccessTime(selectedAsset.lastAccessedAt) }}
+          </n-descriptions-item>
+          <n-descriptions-item label="访问次数">
+            {{ selectedAsset.accessCount ?? 0 }}
+          </n-descriptions-item>
+          <n-descriptions-item label="创建时间">
+            {{ formatDate(selectedAsset.createdAt) }}
+          </n-descriptions-item>
+          <n-descriptions-item label="更新时间">
+            {{ formatDate(selectedAsset.updatedAt) }}
+          </n-descriptions-item>
+          <n-descriptions-item :span="2" label="引用状态">
+            {{ resolveUsageText(selectedAsset) }}
+          </n-descriptions-item>
+          <n-descriptions-item :span="2" label="引用来源">
+            <div class="admin-audio__reference-groups">
+              <div class="admin-audio__reference-group">
+                <strong>场景</strong>
+                <div class="admin-audio__tags">
+                  <n-tag v-for="name in selectedSceneNames" :key="name" size="small" type="info">{{ name }}</n-tag>
+                  <span v-if="!selectedSceneNames.length">无</span>
+                </div>
+              </div>
+              <div class="admin-audio__reference-group">
+                <strong>当前播放状态</strong>
+                <div class="admin-audio__tags">
+                  <n-tag v-for="label in selectedPlaybackLabels" :key="label" size="small" type="warning">{{ label }}</n-tag>
+                  <span v-if="!selectedPlaybackLabels.length">无</span>
+                </div>
+              </div>
+            </div>
+          </n-descriptions-item>
+          <n-descriptions-item :span="2" label="标签">
+            <div class="admin-audio__tags">
+              <n-tag v-for="tag in selectedAsset.tags" :key="tag" size="small">{{ tag }}</n-tag>
+              <span v-if="!selectedAsset.tags?.length">未设置</span>
+            </div>
+          </n-descriptions-item>
+          <n-descriptions-item :span="2" label="备注">
+            {{ selectedAsset.description || '暂无备注' }}
+          </n-descriptions-item>
+        </n-descriptions>
+      </template>
+      <n-empty v-else description="没有可查看的素材信息" />
+    </n-modal>
+
+    <n-modal v-model:show="cleanupModalVisible" preset="dialog" title="清理指定周期未使用素材" :mask-closable="false">
+      <div class="admin-audio__cleanup">
+        <n-radio-group v-model:value="cleanupDays">
+          <n-radio-button v-for="option in cleanupDayOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </n-radio-button>
+        </n-radio-group>
+
+        <div class="admin-audio__cleanup-actions">
+          <n-button @click="loadCleanupPreview" :loading="cleanupLoading">生成预览</n-button>
+        </div>
+
+        <template v-if="cleanupPreview">
+          <n-alert type="info" :show-icon="false">
+            截止 {{ cleanupThresholdText }} 未访问的候选共 {{ cleanupPreview.totalCandidates }} 条，可安全清理 {{ cleanupPreview.safeCandidates }} 条，因引用跳过 {{ cleanupPreview.referencedSkipped }} 条。
+          </n-alert>
+          <n-alert v-if="cleanupPreview.referencedSkipped" type="warning" :show-icon="false">
+            预览结果中仅展示可安全清理的素材；被场景或当前播放引用的素材已自动排除。
+          </n-alert>
+          <n-data-table
+            :columns="cleanupColumns"
+            :data="cleanupPreview.items"
+            :pagination="false"
+            size="small"
+            :max-height="260"
+          />
+        </template>
+      </div>
+
+      <template #action>
+        <n-space justify="end">
+          <n-button @click="cleanupModalVisible = false">关闭</n-button>
+          <n-button type="primary" :disabled="!canExecuteCleanup" :loading="cleanupLoading" @click="executeCleanup">
+            执行安全清理
+          </n-button>
+        </n-space>
+      </template>
+    </n-modal>
+  </div>
+</template>
+
+<style scoped>
+.admin-audio {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.admin-audio__toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.admin-audio__filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.admin-audio__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.admin-audio__stats {
+  color: var(--n-text-color-3);
+  font-size: 13px;
+}
+
+.admin-audio__content {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.admin-audio__table-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid var(--n-border-color);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--n-card-color);
+}
+
+.admin-audio__table-scroll {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.admin-audio__table-card :deep(.n-data-table-wrapper) {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(128, 128, 128, 0.35) transparent;
+}
+
+.admin-audio__table-card :deep(.n-data-table-wrapper)::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.admin-audio__table-card :deep(.n-data-table-wrapper)::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.admin-audio__table-card :deep(.n-data-table-wrapper)::-webkit-scrollbar-thumb {
+  background: rgba(128, 128, 128, 0.35);
+  border-radius: 999px;
+}
+
+.admin-audio__table-card :deep(.n-data-table-wrapper)::-webkit-scrollbar-thumb:hover {
+  background: rgba(128, 128, 128, 0.55);
+}
+
+.admin-audio__pagination {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 12px;
+  border-top: 1px solid var(--n-border-color);
+  margin-top: 12px;
+}
+
+.admin-audio__detail-modal :deep(.n-card__content) {
+  max-height: 70vh;
+  overflow: auto;
+}
+
+.admin-audio__detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.admin-audio__detail-header h3 {
+  margin: 0 0 4px;
+  font-size: 18px;
+}
+
+.admin-audio__detail-header p {
+  margin: 0;
+  color: var(--n-text-color-3);
+}
+
+.admin-audio__name-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.admin-audio__header-trigger {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.admin-audio__header-trigger--sorted,
+.admin-audio__header-trigger--searching {
+  color: var(--n-primary-color);
+}
+
+.admin-audio__header-search-indicator,
+.admin-audio__header-sort-indicator {
+  font-size: 11px;
+  line-height: 1;
+  opacity: 0.8;
+}
+
+.admin-audio__name-button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--n-text-color);
+  cursor: pointer;
+}
+
+.admin-audio__name-button:hover {
+  color: var(--n-primary-color);
+}
+
+.admin-audio__usage-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.admin-audio__desc {
+  margin: 0;
+  color: var(--n-text-color-3);
+  font-size: 12px;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.admin-audio__tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.admin-audio__reference-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.admin-audio__reference-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.admin-audio__action-cell {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.admin-audio__cleanup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-audio__cleanup-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 960px) {
+  .admin-audio__filters {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .admin-audio__actions {
+    width: 100%;
+  }
+
+  .admin-audio__pagination {
+    justify-content: flex-start;
+    overflow-x: auto;
+  }
+}
+</style>

--- a/ui/src/views/admin/admin-settings-audio.vue
+++ b/ui/src/views/admin/admin-settings-audio.vue
@@ -8,6 +8,7 @@ import type {
   AudioAssetUsageSummary,
   AudioBulkDeleteFailure,
   AudioBulkDeleteResult,
+  AudioDeleteImpact,
 } from '@/types/audio';
 import { Search, Refresh, Trash } from '@vicons/tabler';
 import { NButton, NTag, useDialog, useMessage, type DataTableColumns } from 'naive-ui';
@@ -53,7 +54,7 @@ const hasSelection = computed(() => selectionCount.value > 0);
 const cleanupThresholdText = computed(() => (cleanupPreview.value ? formatDate(cleanupPreview.value.thresholdBefore) : ''));
 const selectedSceneNames = computed(() => selectedAsset.value?.usageSummary?.sceneNames || []);
 const selectedPlaybackLabels = computed(() => selectedAsset.value?.usageSummary?.playbackScopeLabels || []);
-const canExecuteCleanup = computed(() => Boolean(cleanupPreview.value?.safeCandidates));
+const canExecuteCleanup = computed(() => Boolean(cleanupPreview.value?.totalCandidates));
 const searchFieldLabelMap: Record<AdminAudioSearchField, string> = {
   all: '全部字段',
   name: '名称',
@@ -118,7 +119,6 @@ function renderHeaderTrigger(label: string, field: AdminAudioSortField, searchFi
 const columns = computed<DataTableColumns<AdminAudioAssetItem>>(() => [
   {
     type: 'selection',
-    disabled: (row) => !row.safeToDelete,
   },
   {
     title: () => renderHeaderTrigger('名称', 'name', 'name'),
@@ -187,8 +187,8 @@ const columns = computed<DataTableColumns<AdminAudioAssetItem>>(() => [
     render: (row) => h('div', { class: 'admin-audio__usage-cell' }, [
       h(
         NTag,
-        { size: 'small', type: row.safeToDelete ? 'success' : 'error' },
-        { default: () => (row.safeToDelete ? '可安全删除' : '仍被引用') },
+        { size: 'small', type: row.safeToDelete ? 'success' : 'warning' },
+        { default: () => (row.safeToDelete ? '可直接删除' : '删除时将解除引用') },
       ),
     ]),
   },
@@ -212,7 +212,6 @@ const columns = computed<DataTableColumns<AdminAudioAssetItem>>(() => [
           size: 'small',
           tertiary: true,
           type: 'error',
-          disabled: !row.safeToDelete,
           onClick: () => confirmDelete(row),
         },
         { default: () => '删除' },
@@ -262,7 +261,7 @@ async function refresh() {
     total.value = resp.data.total || 0;
     worldOptions.value = resp.data.worldOptions || [];
     creatorOptions.value = resp.data.creatorOptions || [];
-    const validSelection = new Set(rows.value.filter((item) => item.safeToDelete).map((item) => item.id));
+    const validSelection = new Set(rows.value.map((item) => item.id));
     checkedRowKeys.value = checkedRowKeys.value.filter((item) => validSelection.has(item));
     if (selectedAssetId.value && rows.value.some((item) => item.id === selectedAssetId.value)) {
       return;
@@ -414,36 +413,49 @@ function openFailureDialog(title: string, failed: AudioBulkDeleteFailure[] = [])
   });
 }
 
-function openReferencedDialog(assetName: string, usage?: AudioAssetUsageSummary) {
-  dialog.warning({
-    title: '素材仍被引用',
-    content: `“${assetName}” 当前无法删除。${usage ? `引用情况：${resolveUsageSummaryText(usage)}` : ''}`,
-    positiveText: '知道了',
-  });
-}
-
 function extractErrorMessage(error: any, fallback: string) {
   return error?.response?.data?.message || error?.response?.data?.error || error?.message || fallback;
 }
 
+function describeDeleteImpact(impact?: AudioDeleteImpact | null) {
+  if (!impact) return '';
+  const sceneCount = impact.detachedSceneCount || 0;
+  const playbackCount = impact.detachedPlaybackStateCount || 0;
+  if (!sceneCount && !playbackCount) {
+    return '';
+  }
+  return `已解除 ${sceneCount} 个场景引用、${playbackCount} 个播放状态引用`;
+}
+
+function describeBulkImpact(result?: AudioBulkDeleteResult | null) {
+  if (!result) return '';
+  const detachedAssets = result.detachedReferencedAssetCount || 0;
+  const sceneCount = result.detachedSceneCount || 0;
+  const playbackCount = result.detachedPlaybackStateCount || 0;
+  if (!detachedAssets && !sceneCount && !playbackCount) {
+    return '';
+  }
+  return `其中 ${detachedAssets} 条素材触发自动解除引用，累计解除 ${sceneCount} 个场景引用、${playbackCount} 个播放状态引用`;
+}
+
 function confirmDelete(row: AdminAudioAssetItem) {
+  const usageText = resolveUsageSummaryText(row.usageSummary);
   dialog.warning({
     title: '安全删除音频素材',
-    content: `确定删除“${row.name}”吗？该操作会执行引用检查。`,
+    content: row.safeToDelete
+      ? `确定删除“${row.name}”吗？当前引用情况：${usageText}。`
+      : `确定删除“${row.name}”吗？该操作会自动解除场景与当前播放状态中的引用。当前引用情况：${usageText}。`,
     positiveText: '删除',
     negativeText: '取消',
     onPositiveClick: async () => {
       try {
-        await api.delete(`/api/v1/admin/audio-assets/${row.id}`);
-        message.success('素材已删除');
+        const resp = await api.delete<{ message?: string; impact?: AudioDeleteImpact }>(`/api/v1/admin/audio-assets/${row.id}`);
+        const impactText = describeDeleteImpact(resp.data?.impact);
+        message.success(impactText ? `素材已删除，${impactText}` : '素材已删除');
         checkedRowKeys.value = checkedRowKeys.value.filter((item) => item !== row.id);
         await refresh();
       } catch (error) {
-        const requestError = error as any;
-        if (requestError?.response?.status === 409) {
-          openReferencedDialog(row.name, requestError?.response?.data?.usage);
-        }
-        message.error(extractErrorMessage(requestError, '删除失败'));
+        message.error(extractErrorMessage(error, '删除失败'));
       }
     },
   });
@@ -453,7 +465,7 @@ function confirmBulkDelete() {
   if (!checkedRowKeys.value.length) return;
   dialog.warning({
     title: '批量安全删除',
-    content: `确定删除选中的 ${checkedRowKeys.value.length} 条素材吗？`,
+    content: `确定删除选中的 ${checkedRowKeys.value.length} 条素材吗？若其中存在被引用素材，系统会自动解除场景与当前播放状态中的引用后再删除。`,
     positiveText: '删除',
     negativeText: '取消',
     onPositiveClick: async () => {
@@ -464,7 +476,8 @@ function confirmBulkDelete() {
         const successCount = resp.data?.successCount || 0;
         const failedCount = resp.data?.failedCount || 0;
         if (successCount) {
-          message.success(`已删除 ${successCount} 条素材`);
+          const impactText = describeBulkImpact(resp.data);
+          message.success(impactText ? `已删除 ${successCount} 条素材，${impactText}` : `已删除 ${successCount} 条素材`);
         }
         if (failedCount) {
           message.warning(`${failedCount} 条素材删除失败`);
@@ -518,7 +531,8 @@ async function executeCleanup() {
     const successCount = resp.data?.successCount || 0;
     const failedCount = resp.data?.failedCount || 0;
     if (successCount) {
-      message.success(`已清理 ${successCount} 条素材`);
+      const impactText = describeBulkImpact(resp.data);
+      message.success(impactText ? `已清理 ${successCount} 条素材，${impactText}` : `已清理 ${successCount} 条素材`);
     } else {
       message.info('没有可清理的素材');
     }
@@ -684,8 +698,8 @@ async function executeCleanup() {
             <h3>{{ selectedAsset.name }}</h3>
             <p>{{ selectedAsset.worldName || '全局素材' }}</p>
           </div>
-          <n-tag :type="selectedAsset.safeToDelete ? 'success' : 'error'">
-            {{ selectedAsset.safeToDelete ? '可安全删除' : '仍被引用' }}
+          <n-tag :type="selectedAsset.safeToDelete ? 'success' : 'warning'">
+            {{ selectedAsset.safeToDelete ? '可直接删除' : '删除时将解除引用' }}
           </n-tag>
         </div>
 
@@ -763,10 +777,10 @@ async function executeCleanup() {
 
         <template v-if="cleanupPreview">
           <n-alert type="info" :show-icon="false">
-            截止 {{ cleanupThresholdText }} 未访问的候选共 {{ cleanupPreview.totalCandidates }} 条，可安全清理 {{ cleanupPreview.safeCandidates }} 条，因引用跳过 {{ cleanupPreview.referencedSkipped }} 条。
+            截止 {{ cleanupThresholdText }} 未访问的候选共 {{ cleanupPreview.totalCandidates }} 条，可直接删除 {{ cleanupPreview.directDeleteCandidates || cleanupPreview.safeCandidates }} 条，需自动解除引用后删除 {{ cleanupPreview.detachThenDeleteCandidates || 0 }} 条。
           </n-alert>
-          <n-alert v-if="cleanupPreview.referencedSkipped" type="warning" :show-icon="false">
-            预览结果中仅展示可安全清理的素材；被场景或当前播放引用的素材已自动排除。
+          <n-alert v-if="cleanupPreview.detachThenDeleteCandidates" type="warning" :show-icon="false">
+            预览列表已包含被引用素材；执行清理时会自动解除场景与当前播放状态中的引用。
           </n-alert>
           <n-data-table
             :columns="cleanupColumns"

--- a/ui/src/views/admin/admin-settings-external-glossary.vue
+++ b/ui/src/views/admin/admin-settings-external-glossary.vue
@@ -22,7 +22,7 @@ type KeywordDisplayStyle = 'standard' | 'minimal' | 'inherit'
 
 const libraryQuery = ref('')
 const termQuery = ref('')
-const termCategoryFilter = ref('')
+const termCategoryFilter = ref<string | null>(null)
 const currentTermPage = ref(1)
 const selectedLibraryIds = ref<string[]>([])
 const selectedTermIds = ref<string[]>([])
@@ -615,7 +615,7 @@ async function handleExportTerms() {
   const library = selectedLibrary.value
   if (!library) return
   try {
-    const items = await store.exportTerms(library.id, termCategoryFilter.value || undefined)
+    const items = await store.exportTerms(library.id, termCategoryFilter.value ?? undefined)
     triggerBlobDownload(
       new Blob([JSON.stringify(items, null, 2)], { type: 'application/json;charset=utf-8' }),
       `external-glossary-terms-${library.name || library.id}.json`,
@@ -790,7 +790,7 @@ function handleCategoryPriorityDragEnd() {
 
 watch(() => store.activeLibraryId, () => {
   selectedTermIds.value = []
-  termCategoryFilter.value = ''
+  termCategoryFilter.value = null
   termQuery.value = ''
   currentTermPage.value = 1
 })
@@ -963,8 +963,8 @@ onMounted(async () => {
                   v-model:value="termCategoryFilter"
                   size="small"
                   clearable
-                  placeholder="分类"
-                  :options="[{ label: '全部分类', value: '' }, ...categoryOptions.map(item => ({ label: item, value: item }))]"
+                  placeholder="全部分类"
+                  :options="categoryOptions.map(item => ({ label: item, value: item }))"
                 />
                 <n-button size="small" :disabled="!selectedTermIds.length" @click="handleBulkTermsEnabled(true)">批量启用</n-button>
                 <n-button size="small" :disabled="!selectedTermIds.length" @click="handleBulkTermsEnabled(false)">批量停用</n-button>

--- a/ui/src/views/admin/admin-settings.vue
+++ b/ui/src/views/admin/admin-settings.vue
@@ -1,11 +1,12 @@
 <script setup lang="tsx">
 import AdminSettingsBase from './admin-settings-base.vue'
 import AdminSettingsBot from './admin-settings-bot.vue'
+import AdminSettingsAudio from './admin-settings-audio.vue'
 import AdminSettingsExternalGlossary from './admin-settings-external-glossary.vue'
 import AdminSettingsUser from './admin-settings-user.vue'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
-type AdminTab = 'basic' | 'bot' | 'user' | 'external-glossary'
+type AdminTab = 'basic' | 'bot' | 'user' | 'external-glossary' | 'audio'
 
 type AdminSettingsBaseExpose = {
   save: () => Promise<void>
@@ -15,6 +16,8 @@ type AdminSettingsBaseExpose = {
 const emit = defineEmits(['close']);
 const activeTab = ref<AdminTab>('basic');
 const basicSettingsRef = ref<AdminSettingsBaseExpose | null>(null);
+const audioDrawerVisible = ref(false);
+const lastNonAudioTab = ref<Exclude<AdminTab, 'audio'>>('basic');
 
 const showSaveAction = computed(() => activeTab.value === 'basic');
 const basicSettingsModified = computed(() => {
@@ -22,8 +25,21 @@ const basicSettingsModified = computed(() => {
   return basicSettingsRef.value?.isModified() ?? false;
 });
 
+watch(activeTab, (value, previous) => {
+  if (value === 'audio') {
+    audioDrawerVisible.value = true;
+    activeTab.value = previous === 'audio' ? lastNonAudioTab.value : (previous as Exclude<AdminTab, 'audio'> | undefined) || 'basic';
+    return;
+  }
+  lastNonAudioTab.value = value as Exclude<AdminTab, 'audio'>;
+});
+
 const cancel = () => {
   emit('close');
+}
+
+const closeAudioDrawer = () => {
+  audioDrawerVisible.value = false;
 }
 
 const saveBasicSettings = async () => {
@@ -60,7 +76,27 @@ const saveBasicSettings = async () => {
       <n-tab-pane name="external-glossary" tab="外挂世界术语">
         <admin-settings-external-glossary />
       </n-tab-pane>
+      <n-tab-pane name="audio" tab="音频素材管理" />
     </n-tabs>
+
+    <n-drawer
+      v-model:show="audioDrawerVisible"
+      :width="'min(1280px, 96vw)'"
+      placement="right"
+      class="sc-admin-settings-audio-drawer"
+    >
+      <n-drawer-content closable body-content-style="padding: 0;">
+        <template #header>
+          <div class="sc-admin-settings-audio-drawer__header">
+            <span class="sc-admin-settings-audio-drawer__title">音频素材管理</span>
+            <n-button size="small" quaternary @click="closeAudioDrawer">退出</n-button>
+          </div>
+        </template>
+        <div class="sc-admin-settings-audio-drawer__body">
+          <admin-settings-audio />
+        </div>
+      </n-drawer-content>
+    </n-drawer>
   </div>
 </template>
 
@@ -96,13 +132,45 @@ const saveBasicSettings = async () => {
 }
 
 .sc-admin-settings-tabs :deep(.n-tabs-pane-wrapper),
+.sc-admin-settings-tabs :deep(.n-tabs-content),
 .sc-admin-settings-tabs :deep(.n-tab-pane),
 .sc-admin-settings-tabs :deep(.n-tab-pane > *) {
   min-height: 0;
 }
 
+.sc-admin-settings-tabs :deep(.n-tabs-content),
+.sc-admin-settings-tabs :deep(.n-tabs-pane-wrapper) {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
 .sc-admin-settings-tabs :deep(.n-tab-pane) {
   height: 100%;
+  overflow: hidden;
+}
+
+.sc-admin-settings-audio-drawer__header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sc-admin-settings-audio-drawer__title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.sc-admin-settings-audio-drawer__body {
+  height: calc(100vh - 96px);
+  min-height: 0;
+  padding: 16px;
+  overflow: hidden;
+}
+
+.sc-admin-settings-audio-drawer :deep(.n-drawer-content) {
   overflow: hidden;
 }
 
@@ -115,6 +183,11 @@ const saveBasicSettings = async () => {
   .sc-admin-settings-header {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .sc-admin-settings-audio-drawer__body {
+    height: calc(100vh - 88px);
+    padding: 12px;
   }
 }
 </style>

--- a/ui/src/views/chat/chat.vue
+++ b/ui/src/views/chat/chat.vue
@@ -1157,7 +1157,7 @@ const initCharacterCardBadge = (
 };
 
 const initCharacterRemark = (channelId?: string) => {
-  if (!channelId || chat.isObserver) return;
+  if (!channelId) return;
   void characterRemarkStore.requestRemarkSnapshot(channelId);
 };
 

--- a/ui/src/views/chat/chat.vue
+++ b/ui/src/views/chat/chat.vue
@@ -19669,10 +19669,24 @@ onBeforeUnmount(() => {
   font-size: 12px;
   color: var(--sc-text-secondary);
   margin-right: 4px;
+  white-space: nowrap;
 }
 
 .whisper-pill-tag {
-  max-width: 100px;
+  flex: 0 1 auto;
+  max-width: clamp(96px, 22vw, 220px);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.whisper-pill-tag :deep(.n-tag__content) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.whisper-pill-tag :deep(.n-tag__close) {
+  flex: 0 0 auto;
 }
 
 .identity-switcher-cell {

--- a/ui/src/views/chat/chat.vue
+++ b/ui/src/views/chat/chat.vue
@@ -3322,7 +3322,7 @@ const maybePromptIdentitySync = async () => {
       resolve(value);
     };
     dialog.warning({
-      title: '同步其他频道角色？',
+      title: '从其他频道同步角色？',
       content: '当前频道角色较少且场内/场外未完整配置，是否从本世界其他频道同步？',
       positiveText: '同步',
       negativeText: '暂不',
@@ -16273,7 +16273,7 @@ onBeforeUnmount(() => {
               <template #icon>
                 <n-icon :component="ArrowsVertical" size="14" />
               </template>
-              同步其他频道
+              从其他频道同步
             </n-button>
             <n-button
               v-if="canManageOtherUserIdentities"
@@ -16491,7 +16491,7 @@ onBeforeUnmount(() => {
   <n-modal
     :show="identitySyncDialogVisible"
     preset="card"
-    title="同步其他频道角色"
+    title="从其他频道同步角色"
     :style="{ width: 'min(520px, 92vw)' }"
     @update:show="identitySyncDialogVisible = $event"
   >

--- a/ui/src/views/chat/chat.vue
+++ b/ui/src/views/chat/chat.vue
@@ -1119,7 +1119,7 @@ const fetchRibbonRoleOptions = async (channelId?: string | null) => {
     const items = Array.isArray(payload?.items) ? payload.items : [];
     const mapped = items
       .map((item) => ({
-        id: String(item.id || ''),
+        id: String(item.id || '').trim(),
         label: item.label || '未命名角色',
       }))
       .filter((item) => item.id);

--- a/ui/src/views/chat/components/CharacterCardPanel.vue
+++ b/ui/src/views/chat/components/CharacterCardPanel.vue
@@ -150,7 +150,7 @@ const syncBadgeTemplateToWorld = async () => {
 
 const loadPanelData = async (channelId: string) => {
   await cardStore.loadCards(channelId);
-  await templateStore.ensureTemplatesLoaded();
+  await templateStore.ensureTemplatesLoaded({ worldId: currentWorldId.value || undefined });
   await templateStore.loadBindings(channelId);
   await avatarStore.loadBindings(channelId);
   await avatarStore.migrateLegacyBindings(
@@ -322,6 +322,14 @@ const managedTemplates = computed(() => {
   });
 });
 
+const canManageWorldSharedTemplates = computed(() => canSyncBadgeTemplate.value && !!currentWorldId.value);
+
+const canEditTemplateItem = (item: CharacterCardTemplate) => !item.readonly;
+
+const canToggleWorldSharedTemplate = (item: CharacterCardTemplate) => {
+  return canManageWorldSharedTemplates.value && !item.readonly;
+};
+
 const filteredManagedTemplates = computed(() => {
   const keyword = templateSearchKeyword.value.trim().toLowerCase();
   if (!keyword) return managedTemplates.value;
@@ -425,7 +433,7 @@ const resolveTemplateSheetType = () => resolveSheetType(templateSheetTypePreset.
 
 const openTemplateManager = async () => {
   if (!ensureCharacterApiEnabled()) return;
-  await templateStore.ensureTemplatesLoaded();
+  await templateStore.ensureTemplatesLoaded({ worldId: currentWorldId.value || undefined });
   templateManagerVisible.value = true;
 };
 
@@ -442,6 +450,7 @@ const openTemplateCreateModal = () => {
 
 const openTemplateEditModal = (item: CharacterCardTemplate) => {
   if (!ensureCharacterApiEnabled()) return;
+  if (item.readonly) return;
   templateEditingId.value = item.id;
   templateName.value = item.name;
   setTemplateSheetType(item.sheetType || '');
@@ -495,6 +504,7 @@ const handleSaveTemplate = async () => {
 
 const handleDeleteTemplate = async (item: CharacterCardTemplate) => {
   if (!ensureCharacterApiEnabled()) return;
+  if (item.readonly) return;
   try {
     await templateStore.deleteTemplate(item.id);
     message.success('模板已删除');
@@ -514,6 +524,23 @@ const handleCopyTemplate = async (item: CharacterCardTemplate) => {
     message.success('模板已复制');
   } catch (e: any) {
     message.error(e?.response?.data?.error || e?.message || '模板复制失败');
+  }
+};
+
+const toggleTemplateWorldShared = async (item: CharacterCardTemplate) => {
+  if (!ensureCharacterApiEnabled()) return;
+  const worldId = currentWorldId.value;
+  if (!worldId || item.readonly) return;
+  try {
+    if (item.isSharedToCurrentWorld) {
+      await templateStore.unshareTemplateFromWorld(worldId, item.id);
+      message.success('已取消世界共享');
+    } else {
+      await templateStore.shareTemplateToWorld(worldId, item.id);
+      message.success('已设为世界共享');
+    }
+  } catch (e: any) {
+    message.error(e?.response?.data?.message || e?.response?.data?.error || e?.message || '设置失败');
   }
 };
 
@@ -873,7 +900,7 @@ const openCharacterSheetWindow = async (
       cardData = cardStore.activeCards[channelId];
     }
     const effectiveCardData = cardStore.getActiveCardId(channelId) === card.id ? cardData : undefined;
-    await templateStore.ensureTemplatesLoaded();
+    await templateStore.ensureTemplatesLoaded({ worldId: currentWorldId.value || undefined });
     await templateStore.ensureBindingsLoaded(channelId);
     const resolvedSheetType = (effectiveCardData?.type || card.sheetType || '').trim();
     const fallbackTemplate = sheetStore.getTemplate(card.id, resolvedSheetType);
@@ -1282,18 +1309,31 @@ const openEditPanel = async (card: CharacterCard) => {
             <span>{{ tpl.name }}</span>
             <div class="template-manager__tags">
               <n-tag size="small" :bordered="false">{{ tpl.sheetType || '通用' }}</n-tag>
-              <n-tag v-if="tpl.isGlobalDefault" size="small" type="info" :bordered="false">全局默认</n-tag>
-              <n-tag v-if="tpl.isSheetDefault" size="small" type="success" :bordered="false">规制默认</n-tag>
+              <n-tag v-if="tpl.access === 'world_shared'" size="small" type="warning" :bordered="false">世界共享</n-tag>
+              <n-tag v-else size="small" type="default" :bordered="false">我的模板</n-tag>
+              <n-tag v-if="tpl.isSharedToCurrentWorld && tpl.access !== 'world_shared'" size="small" type="primary" :bordered="false">已共享</n-tag>
+              <n-tag v-if="tpl.isGlobalDefault && !tpl.readonly" size="small" type="info" :bordered="false">全局默认</n-tag>
+              <n-tag v-if="tpl.isSheetDefault && !tpl.readonly" size="small" type="success" :bordered="false">规制默认</n-tag>
             </div>
           </div>
         </template>
         <div class="template-manager__preview">{{ formatTemplatePreview(tpl.content) || '空模板' }}</div>
+        <div v-if="tpl.access === 'world_shared' && tpl.sharedByNickname" class="template-manager__meta">共享者：{{ tpl.sharedByNickname }}</div>
         <div class="template-manager__actions">
-          <n-button text size="small" :disabled="characterApiDisabled" @click="openTemplateEditModal(tpl)">编辑</n-button>
+          <n-button
+            v-if="canToggleWorldSharedTemplate(tpl)"
+            text
+            size="small"
+            :disabled="characterApiDisabled"
+            @click="toggleTemplateWorldShared(tpl)"
+          >
+            {{ tpl.isSharedToCurrentWorld ? '取消世界共享' : '设为世界共享' }}
+          </n-button>
+          <n-button v-if="canEditTemplateItem(tpl)" text size="small" :disabled="characterApiDisabled" @click="openTemplateEditModal(tpl)">编辑</n-button>
           <n-button text size="small" :disabled="characterApiDisabled" @click="handleCopyTemplate(tpl)">复制</n-button>
-          <n-button text size="small" :disabled="characterApiDisabled" @click="setAsGlobalDefault(tpl)">设为全局默认</n-button>
-          <n-button text size="small" :disabled="characterApiDisabled" @click="setAsSheetDefault(tpl)">设为规制默认</n-button>
-          <n-popconfirm @positive-click="handleDeleteTemplate(tpl)">
+          <n-button v-if="canEditTemplateItem(tpl)" text size="small" :disabled="characterApiDisabled" @click="setAsGlobalDefault(tpl)">设为全局默认</n-button>
+          <n-button v-if="canEditTemplateItem(tpl)" text size="small" :disabled="characterApiDisabled" @click="setAsSheetDefault(tpl)">设为规制默认</n-button>
+          <n-popconfirm v-if="canEditTemplateItem(tpl)" @positive-click="handleDeleteTemplate(tpl)">
             <template #trigger>
               <n-button text size="small" type="error" :disabled="characterApiDisabled">删除</n-button>
             </template>
@@ -1523,6 +1563,12 @@ const openEditPanel = async (card: CharacterCard) => {
   font-size: 0.78rem;
   color: var(--sc-text-secondary);
   line-height: 1.35;
+}
+
+.template-manager__meta {
+  margin-top: 0.35rem;
+  font-size: 0.72rem;
+  color: var(--sc-text-secondary);
 }
 
 .template-manager__actions {

--- a/ui/src/views/chat/components/CharacterCardPanel.vue
+++ b/ui/src/views/chat/components/CharacterCardPanel.vue
@@ -557,7 +557,7 @@ const setAsGlobalDefault = async (item: CharacterCardTemplate) => {
 const setAsSheetDefault = async (item: CharacterCardTemplate) => {
   if (!ensureCharacterApiEnabled()) return;
   if (!(item.sheetType || '').trim()) {
-    message.warning('该模板缺少规制类型，无法设为规制默认');
+    message.warning('该模板缺少规则类型，无法设为规则默认');
     return;
   }
   try {
@@ -612,7 +612,7 @@ const handleCreateCard = async () => {
   }
   const sheetType = resolveSheetType(newCardSheetTypePreset.value, newCardSheetTypeCustom.value);
   if (!sheetType) {
-    message.warning('请输入自定义规制类型');
+    message.warning('请输入自定义规则类型');
     return;
   }
   creating.value = true;
@@ -1104,7 +1104,7 @@ const openEditPanel = async (card: CharacterCard) => {
           size="small"
           clearable
           :disabled="characterApiDisabled"
-          placeholder="搜索人物卡（名称/规制/属性）"
+          placeholder="搜索人物卡（名称/规则/属性）"
         />
       </div>
 
@@ -1266,7 +1266,7 @@ const openEditPanel = async (card: CharacterCard) => {
         <n-input
           v-if="newCardSheetTypePreset === 'custom'"
           v-model:value="newCardSheetTypeCustom"
-          placeholder="输入自定义规制类型"
+          placeholder="输入自定义规则类型"
           class="sheet-type-custom-input"
           :disabled="characterApiDisabled"
         />
@@ -1287,7 +1287,7 @@ const openEditPanel = async (card: CharacterCard) => {
         <n-select
           v-model:value="templateFilterSheetType"
           :options="sheetTypeOptions.filter(opt => opt.value !== 'custom')"
-          placeholder="全部规制"
+          placeholder="全部规则"
           size="small"
           clearable
           :disabled="characterApiDisabled"
@@ -1313,7 +1313,7 @@ const openEditPanel = async (card: CharacterCard) => {
               <n-tag v-else size="small" type="default" :bordered="false">我的模板</n-tag>
               <n-tag v-if="tpl.isSharedToCurrentWorld && tpl.access !== 'world_shared'" size="small" type="primary" :bordered="false">已共享</n-tag>
               <n-tag v-if="tpl.isGlobalDefault && !tpl.readonly" size="small" type="info" :bordered="false">全局默认</n-tag>
-              <n-tag v-if="tpl.isSheetDefault && !tpl.readonly" size="small" type="success" :bordered="false">规制默认</n-tag>
+              <n-tag v-if="tpl.isSheetDefault && !tpl.readonly" size="small" type="success" :bordered="false">规则默认</n-tag>
             </div>
           </div>
         </template>
@@ -1332,7 +1332,7 @@ const openEditPanel = async (card: CharacterCard) => {
           <n-button v-if="canEditTemplateItem(tpl)" text size="small" :disabled="characterApiDisabled" @click="openTemplateEditModal(tpl)">编辑</n-button>
           <n-button text size="small" :disabled="characterApiDisabled" @click="handleCopyTemplate(tpl)">复制</n-button>
           <n-button v-if="canEditTemplateItem(tpl)" text size="small" :disabled="characterApiDisabled" @click="setAsGlobalDefault(tpl)">设为全局默认</n-button>
-          <n-button v-if="canEditTemplateItem(tpl)" text size="small" :disabled="characterApiDisabled" @click="setAsSheetDefault(tpl)">设为规制默认</n-button>
+          <n-button v-if="canEditTemplateItem(tpl)" text size="small" :disabled="characterApiDisabled" @click="setAsSheetDefault(tpl)">设为规则默认</n-button>
           <n-popconfirm v-if="canEditTemplateItem(tpl)" @positive-click="handleDeleteTemplate(tpl)">
             <template #trigger>
               <n-button text size="small" type="error" :disabled="characterApiDisabled">删除</n-button>
@@ -1359,12 +1359,12 @@ const openEditPanel = async (card: CharacterCard) => {
       <n-form-item label="模板名称">
         <n-input v-model:value="templateName" maxlength="100" placeholder="输入模板名称" :disabled="characterApiDisabled" />
       </n-form-item>
-      <n-form-item label="规制类型">
+      <n-form-item label="规则类型">
         <n-select v-model:value="templateSheetTypePreset" :options="sheetTypeOptions" :disabled="characterApiDisabled" />
         <n-input
           v-if="templateSheetTypePreset === 'custom'"
           v-model:value="templateSheetTypeCustom"
-          placeholder="输入自定义规制类型"
+          placeholder="输入自定义规则类型"
           class="sheet-type-custom-input"
           :disabled="characterApiDisabled"
         />
@@ -1381,7 +1381,7 @@ const openEditPanel = async (card: CharacterCard) => {
       <n-form-item label="默认设置">
         <div class="template-manager__defaults">
           <n-checkbox v-model:checked="templateGlobalDefault" :disabled="characterApiDisabled">设为全局默认</n-checkbox>
-          <n-checkbox v-model:checked="templateSheetDefault" :disabled="characterApiDisabled">设为规制默认</n-checkbox>
+          <n-checkbox v-model:checked="templateSheetDefault" :disabled="characterApiDisabled">设为规则默认</n-checkbox>
         </div>
       </n-form-item>
     </n-form>

--- a/ui/src/views/chat/components/CharacterCardPanel.vue
+++ b/ui/src/views/chat/components/CharacterCardPanel.vue
@@ -300,7 +300,7 @@ const handleClose = () => {
   emit('update:visible', false);
 };
 
-const templateFilterSheetType = ref('');
+const templateFilterSheetType = ref<string | null>(null);
 const templateSearchKeyword = ref('');
 const cardSearchKeyword = ref('');
 const templateManagerVisible = ref(false);
@@ -315,7 +315,7 @@ const templateSheetDefault = ref(false);
 const templateSaving = ref(false);
 
 const managedTemplates = computed(() => {
-  const filter = templateFilterSheetType.value.trim().toLowerCase();
+  const filter = (templateFilterSheetType.value ?? '').trim().toLowerCase();
   return templateStore.templates.filter(item => {
     if (!filter) return true;
     return (item.sheetType || '').trim().toLowerCase() === filter;
@@ -1259,8 +1259,8 @@ const openEditPanel = async (card: CharacterCard) => {
       <div class="template-manager__toolbar">
         <n-select
           v-model:value="templateFilterSheetType"
-          :options="[{ label: '全部规制', value: '' }, ...sheetTypeOptions.filter(opt => opt.value !== 'custom')]"
-          placeholder="筛选规制"
+          :options="sheetTypeOptions.filter(opt => opt.value !== 'custom')"
+          placeholder="全部规制"
           size="small"
           clearable
           :disabled="characterApiDisabled"

--- a/ui/src/views/chat/components/ChatActionRibbon.vue
+++ b/ui/src/views/chat/components/ChatActionRibbon.vue
@@ -301,6 +301,14 @@ const roleSelectOptions = computed(() => {
   }))
 })
 
+const selectedRoleCount = computed(() => props.filters.roleIds.length)
+const selectedRoleSummary = computed(() => (
+  selectedRoleCount.value > 0
+    ? `已选 ${selectedRoleCount.value} 人`
+    : '筛选角色'
+))
+const renderRoleTagSummary = () => selectedRoleSummary.value
+
 const activeFiltersCount = computed(() => {
   let count = 0
   if (props.filters.icFilter !== 'all') count++
@@ -367,11 +375,13 @@ const cycleIcFilter = () => {
           :value="filters.roleIds"
           @update:value="updateFilter('roleIds', $event)"
           :options="roleSelectOptions"
+          class="ribbon-role-select"
           multiple
           placeholder="筛选角色"
           size="small"
-          style="min-width: 120px"
           clearable
+          :max-tag-count="0"
+          :max-tag-placeholder="renderRoleTagSummary"
         />
       </div>
     </div>
@@ -437,7 +447,7 @@ const cycleIcFilter = () => {
 .action-ribbon {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 1rem;
   padding: 0.9rem 1.1rem;
   background: var(--sc-bg-elevated);
@@ -459,7 +469,7 @@ const cycleIcFilter = () => {
 }
 
 .ribbon-section--filters {
-  flex-shrink: 0;
+  flex: 0 0 auto;
 }
 
 .ribbon-section--actions {
@@ -472,12 +482,47 @@ const cycleIcFilter = () => {
 .ribbon-section--summary {
   flex-shrink: 0;
   min-width: 120px;
+  margin-left: auto;
   justify-content: flex-end;
 }
 
 .filter-group {
   display: flex;
   align-items: center;
+  min-width: 0;
+}
+
+.filter-group:last-child {
+  flex: 0 0 auto;
+}
+
+.ribbon-role-select {
+  width: 10.5rem;
+  min-width: 10.5rem;
+  max-width: 10.5rem;
+}
+
+.ribbon-role-select :deep(.n-base-selection),
+.ribbon-role-select :deep(.n-base-selection-label),
+.ribbon-role-select :deep(.n-base-selection-tags) {
+  min-width: 0;
+}
+
+.ribbon-role-select :deep(.n-base-selection-tags) {
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.ribbon-role-select :deep(.n-tag) {
+  max-width: 100%;
+}
+
+.ribbon-role-select :deep(.n-tag__content) {
+  display: block;
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .filter-summary {
@@ -546,10 +591,21 @@ const cycleIcFilter = () => {
 
   .ribbon-section--filters {
     flex-wrap: wrap;
+    overflow: visible;
+  }
+
+  .filter-group:last-child {
+    flex: 1 1 10rem;
   }
 
   .ribbon-section--actions {
     overflow: visible;
+  }
+
+  .ribbon-role-select {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
   }
 
   .ribbon-actions-grid {

--- a/ui/src/views/chat/components/DisplaySettingsModal.vue
+++ b/ui/src/views/chat/components/DisplaySettingsModal.vue
@@ -175,6 +175,8 @@ watch(
   draft.worldKeywordHighlightEnabled = value.worldKeywordHighlightEnabled
   draft.worldKeywordUnderlineOnly = value.worldKeywordUnderlineOnly
   draft.worldKeywordTooltipEnabled = value.worldKeywordTooltipEnabled
+  draft.worldKeywordTooltipHoverEnabled = value.worldKeywordTooltipHoverEnabled
+  draft.worldKeywordTooltipClickEnabled = value.worldKeywordTooltipClickEnabled
   draft.worldKeywordTooltipTextIndent = value.worldKeywordTooltipTextIndent
   draft.worldKeywordQuickInputEnabled = value.worldKeywordQuickInputEnabled
   draft.worldKeywordQuickInputTrigger = value.worldKeywordQuickInputTrigger
@@ -878,11 +880,26 @@ const handleOpenTutorialHub = () => {
             <template #checked>启用释义气泡</template>
             <template #unchecked>禁用释义气泡</template>
           </n-switch>
+          <n-switch
+            v-model:value="draft.worldKeywordTooltipHoverEnabled"
+            :disabled="!draft.worldKeywordHighlightEnabled || !draft.worldKeywordTooltipEnabled"
+          >
+            <template #checked>自动展开术语解释</template>
+            <template #unchecked>关闭自动展开</template>
+          </n-switch>
+          <n-switch
+            v-model:value="draft.worldKeywordTooltipClickEnabled"
+            :disabled="!draft.worldKeywordHighlightEnabled || !draft.worldKeywordTooltipEnabled"
+          >
+            <template #checked>点击关键词展开</template>
+            <template #unchecked>关闭点击展开</template>
+          </n-switch>
           <n-switch v-model:value="draft.worldKeywordDeduplicateEnabled" :disabled="!draft.worldKeywordHighlightEnabled">
             <template #checked>术语去重</template>
             <template #unchecked>允许重复</template>
           </n-switch>
         </div>
+        <p class="control-desc control-desc--hint">“自动展开术语解释”仅在桌面鼠标悬浮环境下生效</p>
         <div class="keyword-quick-input-row">
           <n-switch v-model:value="draft.worldKeywordQuickInputEnabled">
             <template #checked>术语快捷输入已开启</template>

--- a/ui/src/views/chat/components/UserPresencePopover.vue
+++ b/ui/src/views/chat/components/UserPresencePopover.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { EyeOutline, EyeOffOutline } from '@vicons/ionicons5'
 import Avatar from '@/components/avatar.vue'
 
@@ -32,26 +32,12 @@ interface Emits {
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
-const activeTab = ref<'online' | 'offline'>('online')
-
 const onlineMembers = computed(() => {
   const now = Date.now()
   return props.members.filter(member => {
     const presence = props.presenceMap[member.id]
     return presence && (now - presence.lastPing) < 120000 // 2分钟内算在线
   })
-})
-
-const offlineMembers = computed(() => {
-  const now = Date.now()
-  return props.members.filter(member => {
-    const presence = props.presenceMap[member.id]
-    return !presence || (now - presence.lastPing) >= 120000
-  })
-})
-
-const currentMembers = computed(() => {
-  return activeTab.value === 'online' ? onlineMembers.value : offlineMembers.value
 })
 
 const getMemberDisplayName = (member: Member) => {
@@ -80,22 +66,18 @@ const handleRefresh = () => {
 <template>
   <div class="presence-popover">
     <div class="presence-header">
-      <n-radio-group
-        v-model:value="activeTab"
-        size="small"
-      >
-        <n-radio-button value="online">
-          在线 ({{ onlineMembers.length }})
-        </n-radio-button>
-        <n-radio-button value="offline">
-          离线 ({{ offlineMembers.length }})
-        </n-radio-button>
-      </n-radio-group>
+      <div class="presence-heading">
+        <span class="presence-title">在线成员</span>
+        <span class="presence-count">{{ onlineMembers.length }}</span>
+      </div>
+      <n-button size="tiny" secondary class="presence-refresh" @click="handleRefresh">
+        刷新状态
+      </n-button>
     </div>
 
     <div class="presence-list">
       <div
-        v-for="member in currentMembers"
+        v-for="member in onlineMembers"
         :key="member.id"
         class="presence-item"
       >
@@ -113,11 +95,10 @@ const handleRefresh = () => {
             </span>
           </div>
           <div class="presence-meta">
-            <span v-if="activeTab === 'online'" class="latency">
+            <span class="latency">
               {{ getLatency(member.id) }}ms
             </span>
             <n-icon
-              v-if="activeTab === 'online'"
               :component="isFocused(member.id) ? EyeOutline : EyeOffOutline"
               size="14"
               :class="{ 'focused': isFocused(member.id), 'unfocused': !isFocused(member.id) }"
@@ -126,15 +107,9 @@ const handleRefresh = () => {
         </div>
       </div>
 
-      <div v-if="currentMembers.length === 0" class="presence-empty">
-        {{ activeTab === 'online' ? '暂无在线成员' : '暂无离线成员' }}
+      <div v-if="onlineMembers.length === 0" class="presence-empty">
+        当前暂无在线成员
       </div>
-    </div>
-
-    <div class="presence-footer">
-      <n-button size="small" @click="handleRefresh">
-        刷新状态
-      </n-button>
     </div>
   </div>
 </template>
@@ -151,21 +126,40 @@ const handleRefresh = () => {
 
 .presence-header {
   display: flex;
-  justify-content: center;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
-:deep(.n-radio-group) {
+.presence-heading {
   display: inline-flex;
-  background: rgba(15, 23, 42, 0.04);
-  border-radius: 0.75rem;
-  padding: 0.125rem;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
 }
 
-:deep(.n-radio-button) {
-  min-width: 6.5rem;
+.presence-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--sc-text-primary, #1f2937);
+}
+
+.presence-count {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
-  border-radius: 0.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.14);
+  color: #2563eb;
   font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.presence-refresh {
+  flex-shrink: 0;
 }
 
 .presence-list {
@@ -208,6 +202,15 @@ const handleRefresh = () => {
   color: #fff;
 }
 
+:global([data-display-palette='night']) .presence-popover .presence-title {
+  color: #fff;
+}
+
+:global([data-display-palette='night']) .presence-popover .presence-count {
+  background: rgba(96, 165, 250, 0.2);
+  color: #93c5fd;
+}
+
 .presence-meta {
   display: flex;
   align-items: center;
@@ -235,13 +238,6 @@ const handleRefresh = () => {
   text-align: center;
   color: #9ca3af;
   font-size: 0.875rem;
-  padding: 1rem;
-}
-
-.presence-footer {
-  display: flex;
-  justify-content: center;
-  border-top: 1px solid rgba(0, 0, 0, 0.06);
-  padding-top: 0.75rem;
+  padding: 1.5rem 1rem;
 }
 </style>

--- a/ui/src/views/chat/components/character-sheet/CharacterSheetWindow.vue
+++ b/ui/src/views/chat/components/character-sheet/CharacterSheetWindow.vue
@@ -129,7 +129,7 @@
                   </n-button>
                   <n-button
                     size="tiny"
-                    :disabled="selectedTemplateMode !== 'managed' || !selectedTemplateId"
+                    :disabled="!canSyncToSelectedTemplate"
                     @click="handleSyncToTemplate"
                   >
                     覆盖同步到模板库
@@ -155,6 +155,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
 import { NIcon, NTabs, NTabPane, NInput, NButton, NSelect, useMessage } from 'naive-ui';
 import { Close, Remove as Minus, Create as Edit, Eye, ChevronBack } from '@vicons/ionicons5';
 import { User } from '@vicons/tabler';
+import { useChatStore } from '@/stores/chat';
 import { useCharacterSheetStore } from '@/stores/characterSheet';
 import { useCharacterCardTemplateStore, type CharacterCardTemplateMode } from '@/stores/characterCardTemplate';
 import { resolveAttachmentUrl } from '@/composables/useAttachmentResolver';
@@ -164,6 +165,7 @@ const props = defineProps<{
   windowId: string;
 }>();
 
+const chatStore = useChatStore();
 const sheetStore = useCharacterSheetStore();
 const templateStore = useCharacterCardTemplateStore();
 const message = useMessage();
@@ -186,9 +188,18 @@ const templateModeOptions = [
 const managedTemplateOptions = computed(() => {
   const sheetType = windowData.value?.sheetType || '';
   return templateStore.getTemplatesBySheetType(sheetType).map(item => ({
-    label: `${item.name}${item.sheetType ? ` [${item.sheetType}]` : ''}`,
+    label: item.access === 'world_shared'
+      ? `${item.name}${item.sharedByNickname ? ` [世界共享:${item.sharedByNickname}]` : ' [世界共享]'}`
+      : `${item.name}${item.sheetType ? ` [${item.sheetType}]` : ''}`,
     value: item.id,
   }));
+});
+
+const selectedTemplate = computed(() => templateStore.getTemplateById(selectedTemplateId.value));
+
+const canSyncToSelectedTemplate = computed(() => {
+  if (selectedTemplateMode.value !== 'managed' || !selectedTemplateId.value) return false;
+  return !selectedTemplate.value?.readonly;
 });
 
 const isMobile = ref(false);
@@ -394,6 +405,10 @@ const handleSyncToTemplate = async () => {
     message.warning('请先选择模板');
     return;
   }
+  if (selectedTemplate.value?.readonly) {
+    message.warning('世界共享模板不可直接覆盖，请先另存为新模板');
+    return;
+  }
   try {
     await sheetStore.syncCurrentTemplateToTemplate(props.windowId, selectedTemplateId.value);
     message.success('已同步到模板库');
@@ -461,7 +476,7 @@ watch(
 onMounted(() => {
   checkMobile();
   window.addEventListener('resize', checkMobile);
-  void templateStore.ensureTemplatesLoaded();
+  void templateStore.ensureTemplatesLoaded({ worldId: chatStore.currentWorldId || undefined });
   syncJsonText();
   syncTemplateText();
   const win = windowData.value;

--- a/ui/src/views/chat/components/chat-item.vue
+++ b/ui/src/views/chat/components/chat-item.vue
@@ -3811,9 +3811,10 @@ const handleRetrySend = () => {
 }
 
 .chat-item > .right > .content.whisper-content {
-  background: var(--chat-whisper-bg, #eef2ff);
-  border: 1px solid var(--chat-whisper-border, rgba(99, 102, 241, 0.35));
+  background: var(--chat-whisper-surface, var(--chat-whisper-bg, #eef2ff));
   color: var(--chat-text-primary, #1f2937);
+  padding-left: calc(var(--chat-message-padding-x, 1.1rem) + 0.34rem);
+  box-shadow: inset 4px 0 0 color-mix(in srgb, var(--chat-whisper-accent, #6366f1) 72%, transparent), var(--chat-message-shadow, none);
 }
 
 .chat-item--layout-bubble > .right {
@@ -4427,45 +4428,47 @@ const handleRetrySend = () => {
   display: flex;
   width: 100%;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.38rem;
   font-size: 0.78rem;
   font-weight: 600;
   letter-spacing: 0.01em;
-  color: #4c1d95;
-  background: rgba(99, 102, 241, 0.08);
-  border-radius: 0.65rem;
-  padding: 0.25rem 0.65rem;
-  margin-bottom: 0.55rem;
-  white-space: pre-line;
+  line-height: 1.35;
+  color: var(--chat-whisper-tag-fg, var(--chat-text-secondary, #475569));
+  background: transparent;
+  border-radius: 0;
+  padding: 0;
+  margin-bottom: 0.48rem;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  box-shadow: none;
 }
 
 .whisper-label svg {
   color: inherit;
-  margin-right: 0.35rem;
+  flex: 0 0 auto;
+}
+
+.whisper-label > span {
+  min-width: 0;
+  flex: 1;
 }
 
 .whisper-label--quote {
   font-size: 0.72rem;
-  color: #5b21b6;
+  color: color-mix(in srgb, var(--chat-whisper-accent, #6366f1) 72%, var(--chat-text-secondary, #475569));
   margin-bottom: 0.25rem;
 }
 
-.whisper-content .whisper-label,
 .whisper-content .whisper-label--quote {
-  background: rgba(99, 102, 241, 0.12);
-  color: #4c1d95;
-}
-
-.whisper-content .whisper-label--quote {
-  color: #6d28d9;
+  color: color-mix(in srgb, var(--chat-whisper-accent, #6366f1) 72%, var(--chat-text-secondary, #475569));
 }
 
 .whisper-content .whisper-label svg {
-  color: #4c1d95;
+  color: inherit;
 }
 
 .whisper-content .text-gray-400 {
-  color: #5b21b6;
+  color: color-mix(in srgb, var(--chat-whisper-accent, #6366f1) 48%, var(--chat-text-secondary, #475569));
 }
 
 /* Tone 样式 */
@@ -4507,20 +4510,17 @@ const handleRetrySend = () => {
 }
 
 .chat--layout-compact .chat-item > .right > .content.whisper-content {
-  background: transparent;
+  background: var(--chat-whisper-surface, rgba(99, 102, 241, 0.02));
   border: none;
+  border-radius: 0.65rem;
   color: var(--chat-text-primary);
-  padding-left: 0;
-  padding-right: 0;
+  padding: 0.36rem 0.72rem 0.4rem 0.88rem;
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--chat-whisper-accent, #6366f1) 68%, transparent);
 }
 
 .chat--layout-compact .whisper-label,
 .chat--layout-compact .whisper-label--quote {
-  background: transparent;
-  padding-left: 0;
-  padding-right: 0;
-  border-radius: 0;
-  color: var(--chat-text-secondary);
+  margin-bottom: 0.32rem;
 }
 
 .chat--layout-compact .chat-item--ooc {

--- a/ui/src/views/chat/components/chat-item.vue
+++ b/ui/src/views/chat/components/chat-item.vue
@@ -30,6 +30,7 @@ import { refreshWorldKeywordHighlights } from '@/utils/worldKeywordHighlighter'
 import { createKeywordTooltip } from '@/utils/keywordTooltip'
 import type { KeywordTooltipSessionState } from '@/utils/worldKeywordTooltipCandidates'
 import { formatWorldKeywordSourceLabel } from '@/utils/worldKeywordSourceLabel'
+import { resolveWorldKeywordTooltipInteractionPolicy } from '@/utils/worldKeywordTooltipInteraction'
 import { resolveMessageLinkInfo, renderMessageLinkHtml } from '@/utils/messageLinkRenderer'
 import { MESSAGE_LINK_REGEX, TITLED_MESSAGE_LINK_REGEX, parseMessageLink } from '@/utils/messageLink'
 import { parseSingleIFormEmbedLinkText, updateIFormEmbedLinkSize } from '@/utils/iformEmbedLink'
@@ -1797,7 +1798,21 @@ const compiledKeywords = computed(() => {
 const keywordHighlightEnabled = computed(() => displayStore.settings.worldKeywordHighlightEnabled !== false)
 const keywordUnderlineOnly = computed(() => !!displayStore.settings.worldKeywordUnderlineOnly)
 const keywordTooltipEnabled = computed(() => displayStore.settings.worldKeywordTooltipEnabled !== false)
+const keywordTooltipHoverEnabled = computed(() => displayStore.settings.worldKeywordTooltipHoverEnabled !== false)
+const keywordTooltipClickEnabled = computed(() => displayStore.settings.worldKeywordTooltipClickEnabled !== false)
 const keywordDeduplicateEnabled = computed(() => !!displayStore.settings.worldKeywordDeduplicateEnabled)
+const isFinePointerDevice = computed(() => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return true
+  }
+  return window.matchMedia('(hover: hover) and (pointer: fine)').matches
+})
+const keywordTooltipInteractionPolicy = computed(() => resolveWorldKeywordTooltipInteractionPolicy({
+  tooltipEnabled: keywordTooltipEnabled.value,
+  hoverEnabled: keywordTooltipHoverEnabled.value,
+  clickEnabled: keywordTooltipClickEnabled.value,
+  finePointer: isFinePointerDevice.value,
+}))
 const hasExternalKeywordSource = computed(() => {
   const worldId = chat.currentWorldId
   if (!worldId) {
@@ -1859,6 +1874,7 @@ let keywordTooltipInstance = createKeywordTooltip(keywordTooltipResolver, {
   onKeywordDoubleInvoke: props.worldKeywordEditable ? handleKeywordQuickEdit : undefined,
   underlineOnly: keywordUnderlineOnly.value,
   textIndent: displayStore.settings.worldKeywordTooltipTextIndent,
+  interaction: keywordTooltipInteractionPolicy.value,
   candidateLoader: loadKeywordConflictCandidates,
 })
 
@@ -1892,6 +1908,8 @@ const applyKeywordHighlights = async () => {
     {
       underlineOnly: keywordUnderlineOnly.value,
       deduplicate: keywordDeduplicateEnabled.value,
+      allowHoverOpen: keywordTooltipInteractionPolicy.value.allowHoverOpen,
+      allowClickOpen: keywordTooltipInteractionPolicy.value.allowClickOpen,
       onKeywordDoubleInvoke: props.worldKeywordEditable ? handleKeywordQuickEdit : undefined,
     },
     keywordTooltipEnabled.value ? keywordTooltipInstance : undefined,
@@ -2954,6 +2972,8 @@ watch(
     () => displayStore.settings.worldKeywordHighlightEnabled,
     () => displayStore.settings.worldKeywordUnderlineOnly,
     () => displayStore.settings.worldKeywordTooltipEnabled,
+    () => displayStore.settings.worldKeywordTooltipHoverEnabled,
+    () => displayStore.settings.worldKeywordTooltipClickEnabled,
     () => displayStore.settings.worldKeywordDeduplicateEnabled,
     () => displayStore.settings.worldKeywordTooltipTextIndent,
     () => displayContent.value,
@@ -2967,6 +2987,7 @@ watch(
       onKeywordDoubleInvoke: props.worldKeywordEditable ? handleKeywordQuickEdit : undefined,
       underlineOnly: keywordUnderlineOnly.value,
       textIndent: displayStore.settings.worldKeywordTooltipTextIndent,
+      interaction: keywordTooltipInteractionPolicy.value,
       candidateLoader: loadKeywordConflictCandidates,
     })
     void applyKeywordHighlights()

--- a/ui/src/views/components/ChannelSettings/TabBotWhisperForward.vue
+++ b/ui/src/views/components/ChannelSettings/TabBotWhisperForward.vue
@@ -97,10 +97,10 @@ const normalizeRule = (rule: BotWhisperForwardRule, index: number): BotWhisperFo
 const normalizeConfig = (cfg?: BotWhisperForwardConfig): BotWhisperForwardConfig => {
   const source = (cfg || {}) as any;
   const base = createDefaultConfig();
-  const rules = Array.isArray(source.rules) ? source.rules : [];
+  const rules: unknown[] = Array.isArray(source.rules) ? source.rules : [];
   const normalizedRules = rules
-    .map((rule, index) => normalizeRule(rule, index))
-    .filter((rule) => {
+    .map((rule, index) => normalizeRule(rule as BotWhisperForwardRule, index))
+    .filter((rule: BotWhisperForwardRule) => {
       if (rule.type === 'keyword') {
         return !!rule.keyword;
       }
@@ -276,7 +276,7 @@ const saveConfig = async (applyToWorld = false) => {
 
     <n-space vertical :size="16">
       <n-card size="small" title="基础设置">
-        <n-form label-placement="left" label-width="160" class="base-form">
+        <n-form label-placement="top" label-width="auto" class="base-form base-form--stacked">
           <n-form-item label="启用转发">
             <n-switch v-model:value="configModel.enabled" :disabled="readOnly" />
           </n-form-item>
@@ -290,10 +290,16 @@ const saveConfig = async (applyToWorld = false) => {
             />
           </n-form-item>
           <n-form-item label="规则逻辑">
-            <n-radio-group v-model:value="configModel.ruleLogic" :disabled="readOnly || !configModel.enabled">
-              <n-radio-button v-for="item in ruleLogicOptions" :key="item.value" :value="item.value">
-                {{ item.label }}
-              </n-radio-button>
+            <n-radio-group
+              v-model:value="configModel.ruleLogic"
+              class="rule-logic-group"
+              :disabled="readOnly || !configModel.enabled"
+            >
+              <n-space vertical :size="8" class="rule-logic-options">
+                <n-radio v-for="item in ruleLogicOptions" :key="item.value" :value="item.value">
+                  {{ item.label }}
+                </n-radio>
+              </n-space>
             </n-radio-group>
           </n-form-item>
         </n-form>
@@ -383,6 +389,31 @@ const saveConfig = async (applyToWorld = false) => {
   padding-top: 8px;
 }
 
+.base-form--stacked :deep(.n-form-item) {
+  grid-template-columns: 1fr;
+}
+
+.base-form--stacked :deep(.n-form-item-label) {
+  margin-bottom: 6px;
+  padding-bottom: 0;
+}
+
+.base-form--stacked :deep(.n-form-item-blank) {
+  min-width: 0;
+}
+
+.rule-logic-group {
+  width: 100%;
+}
+
+.rule-logic-options {
+  width: 100%;
+}
+
+.rule-logic-options :deep(.n-radio) {
+  width: 100%;
+}
+
 .rule-item {
   width: 100%;
   border: 1px solid var(--n-border-color);
@@ -430,14 +461,6 @@ const saveConfig = async (applyToWorld = false) => {
 }
 
 @media (max-width: 768px) {
-  .base-form :deep(.n-form-item) {
-    grid-template-columns: 1fr;
-  }
-
-  .base-form :deep(.n-form-item-label) {
-    margin-bottom: 6px;
-  }
-
   .rule-header :deep(.n-space) {
     width: 100%;
   }

--- a/ui/src/views/components/WorldSwitcher.vue
+++ b/ui/src/views/components/WorldSwitcher.vue
@@ -2,6 +2,13 @@
 import { computed, watch, ref, onMounted } from 'vue';
 import { useChatStore } from '@/stores/chat';
 import { useMessage } from 'naive-ui';
+import {
+  WORLD_DESCRIPTION_MAX_DISPLAY_CHARS,
+  WORLD_DESCRIPTION_MAX_WIDTH_UNITS,
+  formatDisplayWidthAsCharCount,
+  getTextDisplayWidthUnits,
+  truncateTextByDisplayWidth,
+} from '@/utils/displayWidth';
 
 const chat = useChatStore();
 const message = useMessage();
@@ -63,6 +70,15 @@ const handleWorldJump = async () => {
     message.error('进入世界失败');
   }
 };
+
+const updateWorldDescription = (value: string) => {
+  worldForm.value.description = truncateTextByDisplayWidth(value, WORLD_DESCRIPTION_MAX_WIDTH_UNITS);
+};
+
+const getDescriptionCountLabel = (value?: string) => {
+  const usedUnits = getTextDisplayWidthUnits(value || '');
+  return `${formatDisplayWidthAsCharCount(usedUnits)}/${WORLD_DESCRIPTION_MAX_DISPLAY_CHARS}`;
+};
 </script>
 
 <template>
@@ -102,13 +118,15 @@ const handleWorldJump = async () => {
         <n-input v-model:value="worldForm.name" placeholder="输入世界名称" />
       </n-form-item>
       <n-form-item label="简介">
-        <n-input
-          v-model:value="worldForm.description"
-          type="textarea"
-          placeholder="简单描述"
-          maxlength="30"
-          show-count
-        />
+        <div class="world-switcher__description-field">
+          <n-input
+            :value="worldForm.description"
+            type="textarea"
+            placeholder="简单描述"
+            @update:value="updateWorldDescription"
+          />
+          <div class="world-switcher__counter">{{ getDescriptionCountLabel(worldForm.description) }}</div>
+        </div>
       </n-form-item>
       <n-form-item label="可见性">
         <n-select
@@ -129,3 +147,29 @@ const handleWorldJump = async () => {
     </template>
   </n-modal>
 </template>
+
+<style scoped>
+.world-switcher__description-field {
+  position: relative;
+  width: 100%;
+}
+
+.world-switcher__description-field :deep(.n-input) {
+  width: 100%;
+}
+
+.world-switcher__description-field :deep(textarea) {
+  padding-right: 4.75rem;
+  padding-bottom: 1.75rem;
+}
+
+.world-switcher__counter {
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--sc-text-secondary);
+  pointer-events: none;
+}
+</style>

--- a/ui/src/views/components/header.vue
+++ b/ui/src/views/components/header.vue
@@ -18,6 +18,7 @@ import { useChannelImagesStore } from '@/stores/channelImages';
 import AudioDrawer from '@/components/audio/AudioDrawer.vue';
 import { useAudioStudioStore } from '@/stores/audioStudio';
 import { useIFormStore } from '@/stores/iform';
+import { sortObserverRoleOptions } from '@/utils/observerRoleOptions';
 
 const AdminSettings = defineAsyncComponent(() => import('../admin/admin-settings.vue'));
 
@@ -499,8 +500,16 @@ const loadObserverRoleOptions = async (channelId?: string | null) => {
     return;
   }
   const seq = ++observerRoleRequestSeq;
+  const identityScopeKey = chat.resolveChannelIdentityScopeKey(normalizedChannelId);
   try {
-    const payload = await chat.channelSpeakerOptions(normalizedChannelId);
+    const [payload, roleConfig] = await Promise.all([
+      chat.channelSpeakerOptions(normalizedChannelId),
+      (identityScopeKey && chat.channelIdentityLoadedAt[identityScopeKey]
+        ? Promise.resolve(chat.getChannelIcOocRoleConfig(normalizedChannelId))
+        : chat.loadChannelIdentities(normalizedChannelId, false)
+          .then(() => chat.getChannelIcOocRoleConfig(normalizedChannelId))
+          .catch(() => chat.getChannelIcOocRoleConfig(normalizedChannelId))),
+    ]);
     if (seq !== observerRoleRequestSeq) {
       return;
     }
@@ -513,7 +522,7 @@ const loadObserverRoleOptions = async (channelId?: string | null) => {
     if (!mapped.some((item) => item.value === ROLELESS_FILTER_ID)) {
       mapped.push({ label: '其他', value: ROLELESS_FILTER_ID });
     }
-    observerRoleOptions.value = mapped;
+    observerRoleOptions.value = sortObserverRoleOptions(mapped, roleConfig, ROLELESS_FILTER_ID);
   } catch {
     if (seq === observerRoleRequestSeq) {
       observerRoleOptions.value = [];
@@ -909,7 +918,8 @@ const sidebarToggleIcon = computed(() => sidebarCollapsed.value ? LayoutSidebarL
 }
 
 .sc-actions--observer {
-  flex-wrap: wrap;
+  min-width: 0;
+  flex-wrap: nowrap;
   justify-content: flex-end;
 }
 
@@ -927,9 +937,13 @@ const sidebarToggleIcon = computed(() => sidebarCollapsed.value ? LayoutSidebarL
 
 .sc-ob-filters {
   display: inline-flex;
+  flex: 1 1 auto;
   align-items: center;
   gap: 0.5rem;
   margin-right: 0.2rem;
+  min-width: 0;
+  overflow: hidden;
+  justify-content: flex-end;
 }
 
 .sc-ob-filter-button {
@@ -950,8 +964,33 @@ const sidebarToggleIcon = computed(() => sidebarCollapsed.value ? LayoutSidebarL
 }
 
 .sc-ob-role-select {
-  width: 160px;
-  min-width: 140px;
+  flex: 1 1 12rem;
+  width: auto;
+  min-width: 0;
+  max-width: min(24rem, 100%);
+}
+
+.sc-ob-role-select :deep(.n-base-selection),
+.sc-ob-role-select :deep(.n-base-selection-label),
+.sc-ob-role-select :deep(.n-base-selection-tags) {
+  min-width: 0;
+}
+
+.sc-ob-role-select :deep(.n-base-selection-tags) {
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.sc-ob-role-select :deep(.n-tag) {
+  max-width: 100%;
+}
+
+.sc-ob-role-select :deep(.n-tag__content) {
+  display: block;
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sc-user-button {
@@ -1063,6 +1102,7 @@ const sidebarToggleIcon = computed(() => sidebarCollapsed.value ? LayoutSidebarL
   }
 
   .sc-actions--observer {
+    flex-wrap: wrap;
     row-gap: 0.4rem;
   }
 
@@ -1073,8 +1113,8 @@ const sidebarToggleIcon = computed(() => sidebarCollapsed.value ? LayoutSidebarL
   }
 
   .sc-ob-role-select {
-    width: 130px;
-    min-width: 110px;
+    flex: 1 1 130px;
+    max-width: none;
   }
 
   .sc-user-button {

--- a/ui/src/views/world/WorldDetail.vue
+++ b/ui/src/views/world/WorldDetail.vue
@@ -104,11 +104,16 @@ const handleLeaveWorld = () => {
 
 <template>
   <div class="world-detail-page p-4 space-y-4" v-if="detail?.world">
-    <n-card :title="detail.world.name">
-      <div class="flex items-center gap-2">
-        <p class="text-gray-600 flex-1">{{ detail.world.description }}</p>
-        <n-tag v-if="roleLabel" size="small" type="info">当前身份：{{ roleLabel }}</n-tag>
-      </div>
+    <n-card>
+      <template #header>
+        <div class="world-detail-header">
+          <div class="world-detail-title">{{ detail.world.name }}</div>
+          <n-tag v-if="roleLabel" size="tiny" type="info" class="world-detail-role-tag">
+            当前身份：{{ roleLabel }}
+          </n-tag>
+        </div>
+      </template>
+      <p class="world-detail-description">{{ detail.world.description }}</p>
       <div class="mt-3 world-action-grid">
         <div class="world-action-item">
           <n-button block type="primary" @click="enterWorld">进入</n-button>
@@ -191,6 +196,35 @@ const handleLeaveWorld = () => {
   gap: 12px;
 }
 
+.world-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+}
+
+.world-detail-title {
+  min-width: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.25;
+  word-break: break-word;
+}
+
+.world-detail-role-tag {
+  flex: none;
+  margin-top: 8px;
+}
+
+.world-detail-description {
+  margin: 0;
+  color: var(--n-text-color-3);
+  line-height: 1.75;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .world-action-item :deep(.n-button) {
   height: 44px;
 }
@@ -237,6 +271,16 @@ const handleLeaveWorld = () => {
 .world-invite-card :deep(.n-card__content),
 .world-invite-card :deep(.n-card__footer) {
   background-color: var(--sc-invite-surface);
+}
+
+@media (max-width: 640px) {
+  .world-detail-header {
+    gap: 8px;
+  }
+
+  .world-detail-title {
+    font-size: 1.35rem;
+  }
 }
 
 </style>

--- a/ui/src/views/world/WorldKeywordManager.vue
+++ b/ui/src/views/world/WorldKeywordManager.vue
@@ -161,7 +161,7 @@ const isRichMode = computed({
   },
 })
 
-const categoryFilter = ref('')
+const categoryFilter = ref<string | null>(null)
 const categoryOptions = ref<string[]>([])
 
 // Export modal state
@@ -928,7 +928,7 @@ watch(
     } else {
       clearSelection()
       currentPage.value = 1
-      categoryFilter.value = ''
+      categoryFilter.value = null
     }
   },
 )
@@ -941,6 +941,7 @@ watch(
     }
     clearSelection()
     currentPage.value = 1
+    categoryFilter.value = null
   },
 )
 
@@ -1111,7 +1112,7 @@ onUnmounted(() => {
             clearable
             size="small"
             style="width: 140px"
-            :options="[{ label: '全部分类', value: '' }, ...categoryOptions.map(c => ({ label: c, value: c }))]"
+            :options="categoryOptions.map(c => ({ label: c, value: c }))"
           />
         </div>
         <div v-if="canEdit" class="keyword-manager__toolbar">

--- a/ui/src/views/world/WorldLobby.vue
+++ b/ui/src/views/world/WorldLobby.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, shallowRef, watch, type Component, type CSSProperties } from 'vue';
+import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, shallowRef, watch, type CSSProperties } from 'vue';
 import { useChatStore } from '@/stores/chat';
 import { useDialog, useMessage } from 'naive-ui';
 import { LayoutGrid, LayoutList, Search, Star, StarOff } from '@vicons/tabler';
@@ -10,6 +10,7 @@ import { useUserStore } from '@/stores/user';
 import UserProfile from '@/views/components/user-profile.vue';
 import Avatar from '@/components/avatar.vue';
 import AnnouncementManagerModal from '@/components/announcement/AnnouncementManagerModal.vue';
+import WorldLobbyAnnouncementTicker from '@/components/announcement/WorldLobbyAnnouncementTicker.vue';
 
 type LobbyMode = 'mine' | 'explore';
 type WorldLobbyViewMode = 'list' | 'grid';
@@ -77,7 +78,7 @@ const userProfileShow = ref(false);
 const adminShow = ref(false);
 const inputStatsShow = ref(false);
 const inputStatsLoading = ref(false);
-const inputStatsComponent = shallowRef<Component | null>(null);
+const inputStatsComponent = shallowRef<any>(null);
 const announcementVisible = ref(false);
 const viewMode = ref<WorldLobbyViewMode>(readStoredViewMode());
 const requestSeq = ref(0);
@@ -878,6 +879,8 @@ const handleExplorePageSizeChange = (pageSize: number) => {
         </n-button>
       </div>
     </div>
+
+    <WorldLobbyAnnouncementTicker @open-announcements="openAnnouncementPanel" />
 
     <div class="world-toolbar-row">
       <n-input

--- a/ui/src/views/world/WorldLobby.vue
+++ b/ui/src/views/world/WorldLobby.vue
@@ -1076,7 +1076,7 @@ const handleExplorePageSizeChange = (pageSize: number) => {
             :options="[
               { label: '公开', value: 'public' },
               { label: '私有', value: 'private' },
-              { label: '隐藏链接', value: 'unlisted' },
+              { label: '不公开访问链接', value: 'unlisted' },
             ]"
           />
         </n-form-item>

--- a/ui/src/views/world/WorldLobby.vue
+++ b/ui/src/views/world/WorldLobby.vue
@@ -10,7 +10,9 @@ import { useUserStore } from '@/stores/user';
 import UserProfile from '@/views/components/user-profile.vue';
 import Avatar from '@/components/avatar.vue';
 import AnnouncementManagerModal from '@/components/announcement/AnnouncementManagerModal.vue';
+import AnnouncementPopupModal from '@/components/announcement/AnnouncementPopupModal.vue';
 import WorldLobbyAnnouncementTicker from '@/components/announcement/WorldLobbyAnnouncementTicker.vue';
+import type { AnnouncementItem } from '@/models/announcement';
 import {
   WORLD_DESCRIPTION_MAX_DISPLAY_CHARS,
   WORLD_DESCRIPTION_MAX_WIDTH_UNITS,
@@ -88,6 +90,8 @@ const inputStatsShow = ref(false);
 const inputStatsLoading = ref(false);
 const inputStatsComponent = shallowRef<any>(null);
 const announcementVisible = ref(false);
+const announcementPopupVisible = ref(false);
+const announcementPopupItem = ref<AnnouncementItem | null>(null);
 const viewMode = ref<WorldLobbyViewMode>(readStoredViewMode());
 const requestSeq = ref(0);
 const gridActionOpenWorldId = ref<string | null>(null);
@@ -308,6 +312,11 @@ const refreshCurrentMode = async () => {
 
 const openAnnouncementPanel = () => {
   announcementVisible.value = true;
+};
+
+const openTickerAnnouncementPopup = (item: AnnouncementItem) => {
+  announcementPopupItem.value = item;
+  announcementPopupVisible.value = true;
 };
 
 const resetAndFetchCurrentMode = async () => {
@@ -898,7 +907,7 @@ const handleExplorePageSizeChange = (pageSize: number) => {
       </div>
     </div>
 
-    <WorldLobbyAnnouncementTicker @open-announcements="openAnnouncementPanel" />
+    <WorldLobbyAnnouncementTicker @open-announcement="openTickerAnnouncementPopup" />
 
     <div class="world-toolbar-row">
       <n-input
@@ -1145,6 +1154,10 @@ const handleExplorePageSizeChange = (pageSize: number) => {
       scope-type="lobby"
       title="大厅公告"
       :can-manage="canManageLobbyAnnouncements"
+    />
+    <AnnouncementPopupModal
+      v-model:visible="announcementPopupVisible"
+      :item="announcementPopupItem"
     />
   </div>
 </template>

--- a/ui/src/views/world/WorldLobby.vue
+++ b/ui/src/views/world/WorldLobby.vue
@@ -181,6 +181,11 @@ const formatWorldDescription = (description?: string) => {
   return splitTextByDisplayWidth(limited, WORLD_DESCRIPTION_PREVIEW_LINE_WIDTH_UNITS).join('\n');
 };
 
+const formatWorldGridDescription = (description?: string) => {
+  const value = (description || '暂无简介').trim() || '暂无简介';
+  return value;
+};
+
 const updateCreateDescription = (value: string) => {
   createForm.value.description = truncateTextByDisplayWidth(value, WORLD_DESCRIPTION_MAX_WIDTH_UNITS);
 };
@@ -1005,7 +1010,7 @@ const handleExplorePageSizeChange = (pageSize: number) => {
                 </div>
               </div>
             </div>
-            <div class="world-grid-card__desc">{{ formatWorldDescription(item.world.description) }}</div>
+            <div class="world-grid-card__desc">{{ formatWorldGridDescription(item.world.description) }}</div>
             <div class="world-grid-card__actions">
               <n-button
                 quaternary
@@ -1484,7 +1489,8 @@ const handleExplorePageSizeChange = (pageSize: number) => {
   color: var(--sc-text-secondary);
   font-size: 12px;
   line-height: 1.5;
-  white-space: pre-line;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .world-grid-card__tether-layer {

--- a/ui/src/views/world/WorldLobby.vue
+++ b/ui/src/views/world/WorldLobby.vue
@@ -11,6 +11,16 @@ import UserProfile from '@/views/components/user-profile.vue';
 import Avatar from '@/components/avatar.vue';
 import AnnouncementManagerModal from '@/components/announcement/AnnouncementManagerModal.vue';
 import WorldLobbyAnnouncementTicker from '@/components/announcement/WorldLobbyAnnouncementTicker.vue';
+import {
+  WORLD_DESCRIPTION_MAX_DISPLAY_CHARS,
+  WORLD_DESCRIPTION_MAX_WIDTH_UNITS,
+  WORLD_DESCRIPTION_PREVIEW_LINE_WIDTH_UNITS,
+  WORLD_DESCRIPTION_PREVIEW_MAX_WIDTH_UNITS,
+  formatDisplayWidthAsCharCount,
+  getTextDisplayWidthUnits,
+  splitTextByDisplayWidth,
+  truncateTextByDisplayWidth,
+} from '@/utils/displayWidth';
 
 type LobbyMode = 'mine' | 'explore';
 type WorldLobbyViewMode = 'list' | 'grid';
@@ -39,8 +49,6 @@ interface GridTetherState {
 
 const DEFAULT_PAGE_SIZE = 20;
 const PAGE_SIZES = [10, 20, 50];
-const MAX_DESCRIPTION_LENGTH = 30;
-const DESCRIPTION_LINE_LENGTH = 11;
 const WORLD_VIEW_MODE_STORAGE_KEY = 'sc.world-lobby.view-mode';
 const GRID_TETHER_MAX_DISTANCE = 260;
 const GRID_ENTER_PULSE_DELAY_MS = 40;
@@ -169,12 +177,17 @@ const endRequest = (seq: number) => {
 
 const formatWorldDescription = (description?: string) => {
   const value = (description || '暂无简介').trim() || '暂无简介';
-  const limited = Array.from(value).slice(0, MAX_DESCRIPTION_LENGTH);
-  const segments: string[] = [];
-  for (let i = 0; i < limited.length; i += DESCRIPTION_LINE_LENGTH) {
-    segments.push(limited.slice(i, i + DESCRIPTION_LINE_LENGTH).join(''));
-  }
-  return segments.join('\n');
+  const limited = truncateTextByDisplayWidth(value, WORLD_DESCRIPTION_PREVIEW_MAX_WIDTH_UNITS);
+  return splitTextByDisplayWidth(limited, WORLD_DESCRIPTION_PREVIEW_LINE_WIDTH_UNITS).join('\n');
+};
+
+const updateCreateDescription = (value: string) => {
+  createForm.value.description = truncateTextByDisplayWidth(value, WORLD_DESCRIPTION_MAX_WIDTH_UNITS);
+};
+
+const getDescriptionCountLabel = (value?: string) => {
+  const usedUnits = getTextDisplayWidthUnits(value || '');
+  return `${formatDisplayWidthAsCharCount(usedUnits)}/${WORLD_DESCRIPTION_MAX_DISPLAY_CHARS}`;
 };
 
 const fetchList = async (options: FetchOptions = {}) => {
@@ -1062,13 +1075,15 @@ const handleExplorePageSizeChange = (pageSize: number) => {
           <n-input v-model:value="createForm.name" placeholder="输入世界名称" />
         </n-form-item>
         <n-form-item label="简介">
-          <n-input
-            v-model:value="createForm.description"
-            type="textarea"
-            placeholder="简单介绍这个世界"
-            maxlength="30"
-            show-count
-          />
+          <div class="world-description-field">
+            <n-input
+              :value="createForm.description"
+              type="textarea"
+              placeholder="简单介绍这个世界"
+              @update:value="updateCreateDescription"
+            />
+            <div class="world-description-counter">{{ getDescriptionCountLabel(createForm.description) }}</div>
+          </div>
         </n-form-item>
         <n-form-item label="可见性">
           <n-select
@@ -1326,6 +1341,30 @@ const handleExplorePageSizeChange = (pageSize: number) => {
 .world-desc {
   white-space: pre-line;
   color: var(--sc-text-secondary);
+}
+
+.world-description-field {
+  position: relative;
+  width: 100%;
+}
+
+.world-description-field :deep(.n-input) {
+  width: 100%;
+}
+
+.world-description-field :deep(textarea) {
+  padding-right: 4.75rem;
+  padding-bottom: 1.75rem;
+}
+
+.world-description-counter {
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--sc-text-secondary);
+  pointer-events: none;
 }
 
 .world-row {

--- a/ui/src/views/world/WorldManager.vue
+++ b/ui/src/views/world/WorldManager.vue
@@ -123,7 +123,7 @@ const confirmRemove = () => {
           <n-select v-model:value="form.visibility" :options="[
             { label: '公开', value: 'public' },
             { label: '私有', value: 'private' },
-            { label: '隐藏链接', value: 'unlisted' },
+            { label: '不公开访问链接', value: 'unlisted' },
           ]" />
         </n-form-item>
         <n-form-item label="管理权限">

--- a/ui/src/views/world/WorldManager.vue
+++ b/ui/src/views/world/WorldManager.vue
@@ -3,6 +3,13 @@ import { computed, ref, watch } from 'vue';
 import { useChatStore } from '@/stores/chat';
 import { useDialog, useMessage } from 'naive-ui';
 import { DEFAULT_CARD_TEMPLATE } from '@/utils/characterCardTemplate';
+import {
+  WORLD_DESCRIPTION_MAX_DISPLAY_CHARS,
+  WORLD_DESCRIPTION_MAX_WIDTH_UNITS,
+  formatDisplayWidthAsCharCount,
+  getTextDisplayWidthUnits,
+  truncateTextByDisplayWidth,
+} from '@/utils/displayWidth';
 
 const props = defineProps<{ worldId: string, visible: boolean }>();
 const emit = defineEmits(['update:visible']);
@@ -102,6 +109,15 @@ const confirmRemove = () => {
     onPositiveClick: remove,
   });
 };
+
+const updateDescription = (value: string) => {
+  form.value.description = truncateTextByDisplayWidth(value, WORLD_DESCRIPTION_MAX_WIDTH_UNITS);
+};
+
+const getDescriptionCountLabel = (value?: string) => {
+  const usedUnits = getTextDisplayWidthUnits(value || '');
+  return `${formatDisplayWidthAsCharCount(usedUnits)}/${WORLD_DESCRIPTION_MAX_DISPLAY_CHARS}`;
+};
 </script>
 
 <template>
@@ -112,12 +128,14 @@ const confirmRemove = () => {
           <n-input v-model:value="form.name" />
         </n-form-item>
         <n-form-item label="简介">
-          <n-input
-            type="textarea"
-            v-model:value="form.description"
-            maxlength="30"
-            show-count
-          />
+          <div class="world-manager__description-field">
+            <n-input
+              type="textarea"
+              :value="form.description"
+              @update:value="updateDescription"
+            />
+            <div class="world-manager__counter">{{ getDescriptionCountLabel(form.description) }}</div>
+          </div>
         </n-form-item>
         <n-form-item label="可见性">
           <n-select v-model:value="form.visibility" :options="[
@@ -209,6 +227,30 @@ const confirmRemove = () => {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+.world-manager__description-field {
+  position: relative;
+  width: 100%;
+}
+
+.world-manager__description-field :deep(.n-input) {
+  width: 100%;
+}
+
+.world-manager__description-field :deep(textarea) {
+  padding-right: 4.75rem;
+  padding-bottom: 1.75rem;
+}
+
+.world-manager__counter {
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--sc-text-secondary);
+  pointer-events: none;
 }
 
 .manager-permission-row {


### PR DESCRIPTION
## ✨ 功能更新清单

*   **🎵 音频工作台**：
    *   音频素材空间管理**，删除素材自动清理引用，管理更省心。
    *   音频播放器控制面板全面升级，操作更跟手，界面更简洁。
*   **🤝 角色与世界共享**：
    *   **世界管理员专属**：现可创建只读的“共享角色卡模板”，成员可一键查看并直接引用。
    *   世界大厅顶部新增**滚动公告广播**，重要信息第一时间触达。
    *   世界简介排版优化，内容展示更完整，打破字数截断限制。
*   **💬 聊天体验升级**：
    *   **悄悄话**功能视觉升级，新增醒目的左侧描线与高亮，告别漏看。
    *   世界术语支持自定义触发方式（自动展开 / 点击展开）。
*   **🔧 细节打磨与修复**：
    *   **跨端体验**：修复了角色备注跨端不同步、空缓存数据回退的 Bug。
    *   **频道流畅度**：修复了频道身份更换头像装饰时的报错，以及切换世界后画面未刷新的问题。
    *   **界面清爽化**：成员列表现仅展示“在线成员”；筛选器列表优先显示场内角色。

## 🔍 详细变更

### 🌎 世界与频道模块

- **[Feature] 新增共享角色卡模板**
  - 支持世界管理员创建只读状态的共享角色卡模板，供世界内其他成员直接查看与引用。
- **[Feature] 世界大厅滚动公告广播**
  - 在世界大厅顶部区域添加了轮播样式的公告广播组件。
- **[Fix] 世界大厅公告跳转逻辑修复**
  - 修复了点击大厅滚动公告时，错误打开公告列表而非当前公告详情弹窗的问题。
- **[Refactor] 世界简介展示逻辑优化**
  - 将世界大厅及管理界面的世界简介字数统计改为按“显示宽度”计算，并内嵌字数限制提示。
  - 移除了大厅世界卡片前端显示的字数锁，扩大并优化了简介文本的完整显示范围。
- **[Refactor] 成员在线状态与消息筛选器调整**
  - 简化成员在线状态弹窗，过滤离线用户，仅展示当前在线的成员列表。
  - 频道内按角色筛选消息的下拉列表调整了排序逻辑，优先靠前展示场内角色。
- **[Fix] 跨世界视图刷新修复**
  - 修复了用户切换世界后，频道嵌入窗未能及时刷新、仍残留旧世界内容的问题。

### 🎵 音频工作台与素材管理

- **[Feature] 音频素材空间管理**
  - 在平台管理模块中新增“音频素材空间管理”功能。
  - 添加了级联处理逻辑，在删除音频素材时会自动解除其在平台内的相关引用。
- **[Style] 音频工作台播放控制组件重构**
  - 重新设计了音频工作台的总控及单轨播放控制组件样式，统一采用简洁的嵌入式视觉风格。
- **[Fix] 播放按钮状态切换修复**
  - 修复了音频工作台中总控与单轨播放按钮在操作时状态切换异常的问题。

### 💬 聊天交互与术语配置

- **[Feature] 术语卡片展开触发设置**
  - 在常规设置的“世界术语”配置项中，新增了“自动展开术语解释”与“点击关键词展开”的自定义开关。
- **[Style] 悄悄话视觉样式强化**
  - 为悄悄话的聊天气泡添加了左侧描线与高亮背景。
- **[Fix] 悄悄话标签溢出修复**
  - 修复了当发送目标对象的标签昵称过长时，导致的 UI 布局溢出问题。
- **[Refactor] 私聊转发规则 UI 优化**
  - 对频道设置中“BOT 私聊转发配置”的规则逻辑面板进行了样式重构与优化。

### 🐛 底层数据同步修复

- **[Fix] 头像装饰数据更新异常**
  - 修复了频道身份携带头像装饰数据时，触发数据库更新产生的报错与异常。
- **[Fix] 便签权限与备注同步修复**
  - 修复了便签权限发生变更时，特定情况下前端可见性状态未能同步的问题。
  - 修复了角色备注信息在跨端设备间不同步，以及空快照缓存导致的数据回退问题。
- **[Fix] 筛选器卡死死循环修复**
  - 修复了在人物卡模板管理器与世界术语列表中，取消筛选器“全选”状态时引发页面卡死的问题。

### 📝 文案修正

- **[Refactor] 界面引导文本调整**
  - 将“同步其他频道”修改为“从其他频道同步”。
  - 将“隐藏链接”修改为“不公开访问链接”。
- **[Fix] 错别字订正**
  - 将界面说明文本中错误的“规制”修正为“规则”。