### PR TITLE
feat: 支持 nginx 反向代理子目录部署

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -169,6 +169,10 @@ func normalizeWebRoot(webURL string) string {
 	if !strings.HasPrefix(webRoot, "/") {
 		webRoot = "/" + webRoot
 	}
+	// Collapse consecutive leading slashes to prevent protocol-relative URLs (e.g. "//evil.com")
+	for strings.HasPrefix(webRoot, "//") {
+		webRoot = webRoot[1:]
+	}
 	webRoot = strings.TrimRight(webRoot, "/")
 	if webRoot == "" {
 		return "/"
@@ -203,13 +207,37 @@ func applyPageTitleToIndex(htmlSource string, title string) string {
 	return htmlSource[:start+len("<title>")] + escapedTitle + htmlSource[end:]
 }
 
-func applyFaviconToIndex(htmlSource string, attachmentID string) string {
+func applyFaviconToIndex(htmlSource string, attachmentID string, webURL string) string {
 	trimmed := strings.TrimPrefix(strings.TrimSpace(attachmentID), "id:")
-	if trimmed == "" {
+	if trimmed != "" {
+		iconURL := joinWebPath(webURL, "api/v1/attachment", url.PathEscape(trimmed)) + "?v=" + url.QueryEscape(trimmed)
+		return strings.ReplaceAll(htmlSource, `href="/favicon.ico"`, `href="`+html.EscapeString(iconURL)+`"`)
+	}
+	webRoot := normalizeWebRoot(webURL)
+	if webRoot != "/" {
+		newHref := webRoot + "/favicon.ico"
+		return strings.ReplaceAll(htmlSource, `href="/favicon.ico"`, `href="`+html.EscapeString(newHref)+`"`)
+	}
+	return htmlSource
+}
+
+func applyBasePathToIndex(htmlSource string, webURL string) string {
+	webRoot := normalizeWebRoot(webURL)
+	base := ""
+	if webRoot != "/" {
+		base = webRoot
+	}
+	baseJSON, err := json.Marshal(base)
+	if err != nil {
 		return htmlSource
 	}
-	iconURL := "/api/v1/attachment/" + url.PathEscape(trimmed) + "?v=" + url.QueryEscape(trimmed)
-	return strings.ReplaceAll(htmlSource, `href="/favicon.ico"`, `href="`+html.EscapeString(iconURL)+`"`)
+	script := "<script>window.__SEALCHAT_BASE__=" + string(baseJSON) + ";</script>"
+	headStart := strings.Index(htmlSource, "<head>")
+	if headStart == -1 {
+		return htmlSource
+	}
+	insertAt := headStart + len("<head>")
+	return htmlSource[:insertAt] + script + htmlSource[insertAt:]
 }
 
 const (
@@ -218,15 +246,16 @@ const (
 	frontendShortCacheControl = "public, max-age=300"
 )
 
-func frontendCompressMiddleware() fiber.Handler {
+func frontendCompressMiddleware(webURL string) fiber.Handler {
+	apiPrefix := joinWebPath(webURL, "api/v1")
 	return compress.New(compress.Config{
 		Level: compress.LevelBestSpeed,
 		Next: func(c *fiber.Ctx) bool {
 			p := c.Path()
-			return strings.HasPrefix(p, "/api/v1/audio/stream") ||
-				strings.HasPrefix(p, "/api/v1/attachment/") ||
-				strings.HasPrefix(p, "/api/v1/attachments") ||
-				strings.HasPrefix(p, "/api/v1/gallery/thumbs")
+			return strings.HasPrefix(p, apiPrefix+"/audio/stream") ||
+				strings.HasPrefix(p, apiPrefix+"/attachment/") ||
+				strings.HasPrefix(p, apiPrefix+"/attachments") ||
+				strings.HasPrefix(p, apiPrefix+"/gallery/thumbs")
 		},
 	})
 }
@@ -262,7 +291,8 @@ func renderIndexHTML(c *fiber.Ctx, indexHTML []byte, config *utils.AppConfig) er
 	page := string(indexHTML)
 	if config != nil {
 		page = applyPageTitleToIndex(page, config.PageTitle)
-		page = applyFaviconToIndex(page, config.FaviconAttachmentID)
+		page = applyFaviconToIndex(page, config.FaviconAttachmentID, config.WebUrl)
+		page = applyBasePathToIndex(page, config.WebUrl)
 	}
 	body := []byte(page)
 	etagValue := strongETag(body)
@@ -328,9 +358,9 @@ func Init(config *utils.AppConfig, uiStatic fs.FS) error {
 	app.Use(corsConfig)
 	app.Use(recover.New())
 	app.Use(logger.New())
-	app.Use(frontendCompressMiddleware())
+	app.Use(frontendCompressMiddleware(config.WebUrl))
 
-	v1 := app.Group("/api/v1")
+	v1 := app.Group(joinWebPath(config.WebUrl, "api/v1"))
 	v1.Post("/user-signup", UserSignup)
 	v1.Post("/user-signin", UserSignin)
 	v1.Get("/captcha/new", CaptchaNew)
@@ -814,8 +844,8 @@ func Init(config *utils.AppConfig, uiStatic fs.FS) error {
 
 	registerFrontendStaticRoutes(app, config.WebUrl, uiStatic, renderIndex)
 
-	websocketWorks(app)
-	oneBotWSWorks(app)
+	websocketWorks(app, config.WebUrl)
+	oneBotWSWorks(app, config.WebUrl)
 	startOneBotReverseRuntime()
 
 	return serveAppWithOptionalCertificate(app, config)

--- a/api/chat_websocket.go
+++ b/api/chat_websocket.go
@@ -241,7 +241,7 @@ func getUserConnInfoMap() *utils.SyncMap[string, *utils.SyncMap[*WsSyncConn, *Co
 	return userId2ConnInfoGlobal
 }
 
-func websocketWorks(app *fiber.App) {
+func websocketWorks(app *fiber.App, webUrl string) {
 	channelUsersMap := &utils.SyncMap[string, *utils.SyncSet[string]]{}
 	userId2ConnInfo := &utils.SyncMap[string, *utils.SyncMap[*WsSyncConn, *ConnInfo]]{}
 	channelUsersMapGlobal = channelUsersMap
@@ -565,7 +565,7 @@ func websocketWorks(app *fiber.App) {
 		}
 	}()
 
-	app.Use("/ws", func(c *fiber.Ctx) error {
+	app.Use(joinWebPath(webUrl, "ws"), func(c *fiber.Ctx) error {
 		// IsWebSocketUpgrade returns true if the client
 		// requested upgrade to the WebSocket protocol.
 		if websocket.IsWebSocketUpgrade(c) {
@@ -575,7 +575,7 @@ func websocketWorks(app *fiber.App) {
 		return fiber.ErrUpgradeRequired
 	})
 
-	app.Get("/ws/seal", websocket.New(func(rawConn *websocket.Conn) {
+	app.Get(joinWebPath(webUrl, "ws/seal"), websocket.New(func(rawConn *websocket.Conn) {
 		// websocket.Conn bindings https://pkg.go.dev/github.com/fasthttp/websocket?tab=doc#pkg-index
 		var (
 			msg         []byte

--- a/api/onebot_adapter_test.go
+++ b/api/onebot_adapter_test.go
@@ -177,7 +177,7 @@ func mustOneBotMessageID(t *testing.T, resp *oneBotActionResponse) int64 {
 func startOneBotWSTestServer(t *testing.T) (string, func()) {
 	t.Helper()
 	app := fiber.New()
-	oneBotWSWorks(app)
+	oneBotWSWorks(app, "/")
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/api/onebot_ws.go
+++ b/api/onebot_ws.go
@@ -10,17 +10,18 @@ import (
 	"sealchat/service"
 )
 
-func oneBotWSWorks(app *fiber.App) {
-	app.Use("/onebot/v11/ws", func(c *fiber.Ctx) error {
+func oneBotWSWorks(app *fiber.App, webUrl string) {
+	wsPath := joinWebPath(webUrl, "onebot/v11/ws")
+	app.Use(wsPath, func(c *fiber.Ctx) error {
 		if websocket.IsWebSocketUpgrade(c) {
 			return c.Next()
 		}
 		return fiber.ErrUpgradeRequired
 	})
 
-	app.Get("/onebot/v11/ws", websocket.New(oneBotForwardWSHandler(oneBotSessionRoleUniversal)))
-	app.Get("/onebot/v11/ws/api", websocket.New(oneBotForwardWSHandler(oneBotSessionRoleAPI)))
-	app.Get("/onebot/v11/ws/event", websocket.New(oneBotForwardWSHandler(oneBotSessionRoleEvent)))
+	app.Get(wsPath, websocket.New(oneBotForwardWSHandler(oneBotSessionRoleUniversal)))
+	app.Get(joinWebPath(webUrl, "onebot/v11/ws/api"), websocket.New(oneBotForwardWSHandler(oneBotSessionRoleAPI)))
+	app.Get(joinWebPath(webUrl, "onebot/v11/ws/event"), websocket.New(oneBotForwardWSHandler(oneBotSessionRoleEvent)))
 }
 
 func oneBotForwardWSHandler(role oneBotSessionRole) func(*websocket.Conn) {

--- a/deploy_zh.md
+++ b/deploy_zh.md
@@ -225,6 +225,68 @@ Windows下为zip格式。
 打开浏览器，访问 http://localhost:3212/ 即可使用，第一个注册的帐号会成为管理员账号。
 
 
+## 进阶：使用 nginx 反向代理子目录
+
+如果你希望将 SealChat 挂载到某个子目录下（如 `https://example.com/chat/`），需要同时配置服务端的 `webUrl` 和 nginx 反向代理。
+
+### config.yaml 配置
+
+```yaml
+# 将 webUrl 设置为你的子路径（以 / 开头，不带尾部斜杠）
+webUrl: /chat
+
+# serveAt 保持默认端口，仅供内网访问
+serveAt: :3212
+```
+
+> **注意**：`domain` 参数与路由无关，它只用于 onebot 适配器拼接图片/附件的对外 URL、聊天导出中的绝对链接，以及端口冲突时的自动更新。如需在上述场景使用完整外部 URL，可将 `domain` 设置为 `https://example.com/chat`（含子路径的完整 URL）；否则请保持默认或留空，它不会影响用户访问。
+
+### nginx 配置
+
+SealChat 支持两种 nginx 反代配置方式，**任选其一**：
+
+#### 方式一：保留前缀（推荐）
+
+`proxy_pass` **不带尾部斜杠**，nginx 保留路径前缀转发给 Go 服务。
+
+```nginx
+location /chat/ {
+    proxy_pass http://127.0.0.1:3212;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+使用此方式时，`config.yaml` 中的 `webUrl` 需设置为 `/chat`（与 nginx 子路径一致）。
+
+#### 方式二：剥离前缀
+
+`proxy_pass` **带尾部斜杠**，nginx 剥去路径前缀后转发。
+
+```nginx
+location /chat/ {
+    proxy_pass http://127.0.0.1:3212/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+使用此方式时，`config.yaml` 中的 `webUrl` 需保持默认的 `/`。前端会自动从浏览器 URL 中检测子路径。
+
+配置完成后，访问 `https://example.com/chat/` 即可正常使用。直接访问 `http://localhost:3212/` 会显示主页（前端从浏览器 URL 自动检测子路径）。
+
+> **群晖 Web Station**：如果你使用群晖容器管理器（Container Manager）部署并通过 Web Station 别名门户反代，请参照**方式二**（剥离前缀），`webUrl` 保持默认 `/`。Web Station 会自动剥离子路径前缀。本文测试环境为 DSM 7.3.2。
+
 ## 进阶：使用 PostgreSQL 或 MySQL 作为数据库
 
 SealChat 默认使用 SQLite 作为数据库，这使得它可以双击部署，一键运行。

--- a/ui/index.html
+++ b/ui/index.html
@@ -43,7 +43,12 @@
           return resp.json();
         });
       };
-      var origins = [window.location.origin];
+      var _basePath = window.__SEALCHAT_BASE__;
+      if (!_basePath) {
+        var _p = window.location.pathname.replace(/\/index\.html$/, '').replace(/\/+$/, '');
+        if (_p && _p !== '/') _basePath = _p;
+      }
+      var origins = [window.location.origin + (_basePath || '')];
       var devFallback = window.location.protocol + '//' + window.location.hostname + ':3212';
       if (origins.indexOf(devFallback) === -1) {
         origins.push(devFallback);

--- a/ui/src/stores/_config.ts
+++ b/ui/src/stores/_config.ts
@@ -7,9 +7,27 @@ axios.defaults.withCredentials = true;
 // export const urlBase = '//' + window.location.hostname + ":" + 3212;
 // export const urlBase = '//' + window.location.host + '/';
 
+const _appBase: string = typeof window !== 'undefined'
+  ? ((window as any).__SEALCHAT_BASE__ ?? '')
+  : '';
+
+function detectBasePathFromURL(): string {
+  if (typeof window === 'undefined') return '';
+  let base = window.location.pathname;
+  // Remove /index.html suffix if present
+  base = base.replace(/\/index\.html$/, '');
+  // Remove trailing slashes
+  base = base.replace(/\/+$/, '');
+  // If root path, return empty (no subdirectory)
+  if (base === '' || base === '/') return '';
+  return base;
+}
+
+const _effectiveBase = _appBase || detectBasePathFromURL();
+
 export const urlBase = import.meta.env.MODE === 'development'
   ? '//' + window.location.hostname + ":" + 3212
-  : '//' + window.location.host;
+  : '//' + window.location.host + _effectiveBase;
 
 console.log('mode', import.meta.env.MODE)
 


### PR DESCRIPTION
## 问题

当前版本通过 Docker 部署后，如果使用 nginx 反向代理并以域名子目录（如 `/sealchat/`）访问，无法正常注册和使用。

## 解决方案

全面适配 webUrl 子路径配置，支持两种 nginx 反代模式。

### 后端变更

- **路由统一适配**：所有 API / WebSocket / OneBot / 静态资源路由改用 `joinWebPath(webUrl, ...)`，使路由挂载到 webUrl 子路径下
- **favicon 路径适配**：`applyFaviconToIndex` 新增 webURL 参数，子目录部署时 favicon 路径正确指向
- **base path 注入**：新增 `applyBasePathToIndex`，向 index.html 注入 `window.__SEALCHAT_BASE__` 告知前端基础路径
- **安全增强**：`normalizeWebRoot` 新增连续斜杠折叠，防止 `//evil.com` 协议相对 URL
- **压缩排除路径适配**：`frontendCompressMiddleware` 的排除路径适配 webUrl 前缀

### 前端变更

- **`ui/src/stores/_config.ts`**：urlBase 优先使用 `__SEALCHAT_BASE__`，未设置时自动从 `window.location.pathname` 检测子目录
- **`ui/index.html`**：内联脚本的 origins 拼接 base path，并增加 URL 路径检测兜底

### 两种部署模式

| 模式 | nginx proxy_pass | webUrl | 说明 |
|------|-----------------|--------|------|
| 方式一（推荐） | `http://127.0.0.1:3212`（不带 `/`） | `/chat` | nginx 保留前缀转发，后端路由直接匹配 |
| 方式二 | `http://127.0.0.1:3212/`（带 `/`） | `/`（默认） | nginx 剥离前缀，前端从浏览器 URL 自动检测 |

详细配置见 `deploy_zh.md` 新增章节。

### 测试

已在群晖 DSM 7.3.2 + Container Manager + Web Station 别名门户环境下验证（方式二），注册功能正常。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>