### PR TITLE
功能：为消息右键菜单栏添加“更多”，并链接到二级菜单；添加“归档当前消息前的所有消息”

### DIFF
--- a/api/chat_api_message.go
+++ b/api/chat_api_message.go
@@ -1662,11 +1662,13 @@ func apiMessagePinList(ctx *ChatContext, data *struct {
 	}, nil
 }
 
-func apiMessageArchive(ctx *ChatContext, data *struct {
+type messageArchivePayload struct {
 	ChannelID  string   `json:"channel_id"`
 	MessageIDs []string `json:"message_ids"`
 	Reason     string   `json:"reason"`
-}) (any, error) {
+}
+
+func apiMessageArchive(ctx *ChatContext, data *messageArchivePayload) (any, error) {
 	if strings.TrimSpace(data.ChannelID) == "" {
 		return nil, fmt.Errorf("channel_id 不能为空")
 	}
@@ -1742,6 +1744,70 @@ func apiMessageArchive(ctx *ChatContext, data *struct {
 		MessageIDs []string `json:"message_ids"`
 		Archived   bool     `json:"archived"`
 	}{MessageIDs: lo.Uniq(ids), Archived: true}, nil
+}
+
+type messageArchiveBeforePayload struct {
+	ChannelID string `json:"channel_id"`
+	MessageID string `json:"message_id"`
+}
+
+func apiMessageArchiveBefore(ctx *ChatContext, data *messageArchiveBeforePayload) (any, error) {
+	channelID := strings.TrimSpace(data.ChannelID)
+	messageID := strings.TrimSpace(data.MessageID)
+	if channelID == "" || messageID == "" {
+		return nil, fmt.Errorf("channel_id 和 message_id 不能为空")
+	}
+
+	channel, targets, err := loadArchiveContext(channelID, []string{messageID})
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("目标消息不存在或已删除")
+	}
+	target := targets[0]
+
+	operatorID := ctx.User.ID
+	hasArchivePerm := pm.CanWithChannelRole(operatorID, channelID,
+		pm.PermFuncChannelMessageArchive,
+		pm.PermFuncChannelManageInfo,
+	)
+	operatorRank := getChannelMemberRoleRank(channel, channelID, operatorID)
+	if !hasArchivePerm || operatorRank < channelMemberRoleRankAdmin {
+		return nil, fmt.Errorf("无权限批量归档更早消息")
+	}
+
+	var ids []string
+	err = model.GetDB().
+		Model(&model.MessageModel{}).
+		Where("channel_id = ? AND is_deleted = ? AND is_archived = ?", channelID, false, false).
+		Where(
+			"(display_order < ?) OR (display_order = ? AND created_at < ?) OR (display_order = ? AND created_at = ? AND id < ?)",
+			target.DisplayOrder,
+			target.DisplayOrder,
+			target.CreatedAt,
+			target.DisplayOrder,
+			target.CreatedAt,
+			target.ID,
+		).
+		Pluck("id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) > 0 {
+		_, err = apiMessageArchive(ctx, &messageArchivePayload{
+			ChannelID:  channelID,
+			MessageIDs: ids,
+			Reason:     "归档目标消息之前的所有消息",
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &struct {
+		ArchivedCount int `json:"archived_count"`
+	}{ArchivedCount: len(ids)}, nil
 }
 
 func apiMessageUnarchive(ctx *ChatContext, data *struct {

--- a/api/chat_websocket.go
+++ b/api/chat_websocket.go
@@ -1097,6 +1097,9 @@ func websocketWorks(app *fiber.App, webUrl string) {
 					case "message.archive":
 						apiWrap(ctx, msg, apiMessageArchive)
 						solved = true
+					case "message.archive.before":
+						apiWrap(ctx, msg, apiMessageArchiveBefore)
+						solved = true
 					case "message.unarchive":
 						apiWrap(ctx, msg, apiMessageUnarchive)
 						solved = true

--- a/ui/src/stores/chat.ts
+++ b/ui/src/stores/chat.ts
@@ -6022,6 +6022,23 @@ export const useChatStore = defineStore({
       return payload;
     },
 
+    async archiveMessagesBefore(messageId: string) {
+      const channelId = this.curChannel?.id;
+      const normalizedMessageId = String(messageId || '').trim();
+      if (!channelId || !normalizedMessageId) {
+        throw new Error('归档失败：缺少频道或目标消息');
+      }
+      const resp = await this.sendAPI('message.archive.before', {
+        channel_id: channelId,
+        message_id: normalizedMessageId,
+      });
+      const archivedCount = resp?.data?.archived_count;
+      if (typeof archivedCount !== 'number') {
+        throw new Error('归档失败：服务端未返回有效结果');
+      }
+      return archivedCount;
+    },
+
     async unarchiveMessages(messageIds: string[]) {
       if (!this.curChannel?.id || messageIds.length === 0) return;
       const resp = await this.sendAPI('message.unarchive', {

--- a/ui/src/views/chat/components/ChatRightClickMenu.vue
+++ b/ui/src/views/chat/components/ChatRightClickMenu.vue
@@ -299,6 +299,10 @@ const canSetMessageInsertTarget = computed(() => (
   && !!insertTargetMessageId.value
   && !isArchivedMessage.value
 ));
+const canArchiveMessagesBefore = computed(() => (
+  !!insertTargetMessageId.value
+  && viewerIsAdmin.value
+));
 const isPinnedMessage = computed(() => {
   const raw: any = menuMessage.value.raw;
   if (!raw) {
@@ -772,6 +776,41 @@ const clickToggleMessageInsertTarget = () => {
   chat.messageMenu.show = false;
 };
 
+const clickArchiveMessagesBefore = () => {
+  if (!canArchiveMessagesBefore.value) {
+    return;
+  }
+  const targetMessageId = insertTargetMessageId.value;
+  if (!targetMessageId) {
+    return;
+  }
+  chat.messageMenu.show = false;
+  dialog.warning({
+    title: '归档更早消息',
+    content: '将归档当前消息之前的所有未归档消息，不包含当前消息。确定继续？',
+    positiveText: '归档',
+    negativeText: '取消',
+    iconPlacement: 'top',
+    contentStyle: {
+      color: themeVars.value.textColor2,
+    },
+    maskClosable: false,
+    onPositiveClick: async () => {
+      try {
+        const archivedCount = await chat.archiveMessagesBefore(targetMessageId);
+        if (archivedCount === 0) {
+          message.info('当前消息之前没有需要归档的消息');
+          return;
+        }
+        message.success(`已归档 ${archivedCount} 条消息`);
+      } catch (error) {
+        const errMsg = (error as Error)?.message || '归档失败';
+        message.error(errMsg);
+      }
+    },
+  });
+};
+
 </script>
 
 <template>
@@ -799,6 +838,13 @@ const clickToggleMessageInsertTarget = () => {
     <context-menu-item label="多选" @click="clickMultiSelect" />
     <context-menu-item label="撤回" @click="clickDelete" v-if="isSelfMessage" />
     <context-menu-item label="删除" @click="clickRemove" v-if="canRemoveMessage" />
+    <context-menu-group label="更多">
+      <context-menu-item
+        label="归档该消息前的所有消息"
+        :disabled="!canArchiveMessagesBefore"
+        @click="clickArchiveMessagesBefore"
+      />
+    </context-menu-group>
   </context-menu>
 
   <EmojiPickerModal


### PR DESCRIPTION
1. 一级菜单末尾新增“更多”，使用 ContextMenuGroup 连接二级菜单。
2. 二级菜单新增“归档该消息前的所有消息”。
3. 操作会归档位于选中消息之前的所有未归档消息，消息边界严格依据 display_order → created_at → id 判断。
4. 操作前弹出确认对话框，并反馈实际归档数量。
5. 复用现有归档事件广播、私聊消息可见范围和归档审计记录。